### PR TITLE
Set up Code Owners for the Server Certificate WG

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+docs/BR.md	@cabforum/servercert-chairs
+docs/EVG.md	@cabforum/servercert-chairs
+docs/NSR.md	@cabforum/servercert-chairs


### PR DESCRIPTION
Create a CODEOWNERS file, so that merges to SCWG documents are restricted to @cabforum/servercert-chairs 