### PR TITLE
Add a GitHub Workflow to do Pandoc conversion

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -6,7 +6,7 @@ jobs:
       - name: Checkout the documents
         uses: actions/checkout@v2
       - name: Build the Baseline Requirements
-        uses: cabforum/build-guidelines-action@v1.0.0-rc3
+        uses: cabforum/build-guidelines-action@sleevi_scratch
         with:
           markdown-file: docs/BR.md
           pdf: true
@@ -22,7 +22,7 @@ jobs:
           if-no-files-found: 'error'
           retention-days: 21
       - name: Build the EV Guidelines
-        uses: cabforum/build-guidelines-action@v1.0.0-rc3
+        uses: cabforum/build-guidelines-action@sleevi_scratch
         with:
           markdown-file: docs/EVG.md
           pdf: true
@@ -38,7 +38,7 @@ jobs:
           if-no-files-found: 'error'
           retention-days: 21
       - name: Build the NCSSRs
-        uses: cabforum/build-guidelines-action@v1.0.0-rc3
+        uses: cabforum/build-guidelines-action@sleevi_scratch
         with:
           markdown-file: docs/NSR.md
           pdf: true

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           name: Converted ${{ matrix.document }}
           path: |
-            '**/*.pdf'
-            '**/*.docx'
+            **/*.pdf
+            **/*.docx
           if-no-files-found: 'error'
           retention-days: 21

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -1,55 +1,28 @@
 on: [push, pull_request]
 jobs:
-  build_pandoc:
-    runs-on: ubuntu-latest
+  build_brs:
+    strategy:
+      matrix:
+        document:
+          - 'docs/BR.md'
+          - 'docs/EVG.md'
+          - 'docs/NSR.md'
+    name: Build ${{ matrix.document }}
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout the documents
-        uses: actions/checkout@v2
-      - name: Build the Baseline Requirements
-        uses: cabforum/build-guidelines-action@v1.0.0-rc4
+      - uses: actions/checkout@v2
+      - uses: cabforum/build-guidelines-action@v1.0.0-rc4
         with:
-          markdown-file: docs/BR.md
+          markdown-file: ${{ matrix.document }}
           pdf: true
           docx: true
           lint: true
           draft: true
       - uses: actions/upload-artifact@v2
         with:
-          name: BRs
+          name: Converted ${{ matrix.document }}
           path: |
-            docs/BR.pdf
-            docs/BR.docx
-          if-no-files-found: 'error'
-          retention-days: 21
-      - name: Build the EV Guidelines
-        uses: cabforum/build-guidelines-action@v1.0.0-rc4
-        with:
-          markdown-file: docs/EVG.md
-          pdf: true
-          docx: true
-          lint: true
-          draft: true
-      - uses: actions/upload-artifact@v2
-        with:
-          name: EVGs
-          path: |
-            docs/EVG.pdf
-            docs/EVG.docx
-          if-no-files-found: 'error'
-          retention-days: 21
-      - name: Build the NCSSRs
-        uses: cabforum/build-guidelines-action@v1.0.0-rc4
-        with:
-          markdown-file: docs/NSR.md
-          pdf: true
-          docx: true
-          lint: true
-          draft: true
-      - uses: actions/upload-artifact@v2
-        with:
-          name: NSRs
-          path: |
-            docs/NSR.pdf
-            docs/NSR.docx
+            '**/*.pdf'
+            '**/*.docx'
           if-no-files-found: 'error'
           retention-days: 21

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -1,3 +1,4 @@
+name: Build Draft Guidelines
 on: [push, pull_request]
 jobs:
   build_brs:

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -4,16 +4,16 @@ jobs:
     strategy:
       matrix:
         document:
-          - 'docs/BR.md'
-          - 'docs/EVG.md'
-          - 'docs/NSR.md'
+          - 'BR.md'
+          - 'EVG.md'
+          - 'NSR.md'
     name: Build ${{ matrix.document }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: cabforum/build-guidelines-action@v1.0.0-rc4
         with:
-          markdown-file: ${{ matrix.document }}
+          markdown-file: docs/${{ matrix.document }}
           pdf: true
           docx: true
           lint: true

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -1,0 +1,55 @@
+on: [push, pull_request]
+jobs:
+  build_pandoc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the documents
+        uses: actions/checkout@v2
+      - name: Build the Baseline Requirements
+        uses: cabforum/build-guidelines-action@v1.0.0-rc2
+        with:
+          markdown-file: docs/BR.md
+          pdf: true
+          docx: true
+          lint: true
+          draft: true
+      - uses: actions/upload-artifact@v2
+        with:
+          name: BRs
+          path: |
+            docs/BR.pdf
+            docs/BR.docx
+          if-no-files-found: 'error'
+          retention-days: 21
+      - name: Build the EV Guidelines
+        uses: cabforum/build-guidelines-action@v1.0.0-rc2
+        with:
+          markdown-file: docs/EVG.md
+          pdf: true
+          docx: true
+          lint: true
+          draft: true
+      - uses: actions/upload-artifact@v2
+        with:
+          name: EVGs
+          path: |
+            docs/EVG.pdf
+            docs/EVG.docx
+          if-no-files-found: 'error'
+          retention-days: 21
+      - name: Build the NCSSRs
+        uses: cabforum/build-guidelines-action@v1.0.0-rc2
+        with:
+          markdown-file: docs/NSR.md
+          pdf: true
+          docx: true
+          lint: true
+          draft: true
+      - uses: actions/upload-artifact@v2
+        with:
+          name: NSRs
+          path: |
+            docs/NSR.pdf
+            docs/NSR.docx
+          if-no-files-found: 'error'
+          retention-days: 21

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -6,7 +6,7 @@ jobs:
       - name: Checkout the documents
         uses: actions/checkout@v2
       - name: Build the Baseline Requirements
-        uses: cabforum/build-guidelines-action@sleevi_scratch
+        uses: cabforum/build-guidelines-action@v1.0.0-rc4
         with:
           markdown-file: docs/BR.md
           pdf: true
@@ -22,7 +22,7 @@ jobs:
           if-no-files-found: 'error'
           retention-days: 21
       - name: Build the EV Guidelines
-        uses: cabforum/build-guidelines-action@sleevi_scratch
+        uses: cabforum/build-guidelines-action@v1.0.0-rc4
         with:
           markdown-file: docs/EVG.md
           pdf: true
@@ -38,7 +38,7 @@ jobs:
           if-no-files-found: 'error'
           retention-days: 21
       - name: Build the NCSSRs
-        uses: cabforum/build-guidelines-action@sleevi_scratch
+        uses: cabforum/build-guidelines-action@v1.0.0-rc4
         with:
           markdown-file: docs/NSR.md
           pdf: true

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           name: Converted ${{ matrix.document }}
           path: |
-            **/*.pdf
-            **/*.docx
+            docs/*.pdf
+            docs/*.docx
           if-no-files-found: 'error'
           retention-days: 21

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -6,7 +6,7 @@ jobs:
       - name: Checkout the documents
         uses: actions/checkout@v2
       - name: Build the Baseline Requirements
-        uses: cabforum/build-guidelines-action@v1.0.0-rc2
+        uses: cabforum/build-guidelines-action@v1.0.0-rc3
         with:
           markdown-file: docs/BR.md
           pdf: true
@@ -22,7 +22,7 @@ jobs:
           if-no-files-found: 'error'
           retention-days: 21
       - name: Build the EV Guidelines
-        uses: cabforum/build-guidelines-action@v1.0.0-rc2
+        uses: cabforum/build-guidelines-action@v1.0.0-rc3
         with:
           markdown-file: docs/EVG.md
           pdf: true
@@ -38,7 +38,7 @@ jobs:
           if-no-files-found: 'error'
           retention-days: 21
       - name: Build the NCSSRs
-        uses: cabforum/build-guidelines-action@v1.0.0-rc2
+        uses: cabforum/build-guidelines-action@v1.0.0-rc3
         with:
           markdown-file: docs/NSR.md
           pdf: true


### PR DESCRIPTION
This adds a basic workflow that will convert `docs/BR.md`, `docs/EVG.md`, and `docs/NSR.md` to `pdf` and `docx` using the https://github.com/cabforum/build-guidelines-action GitHub Action, attaching the results as artifacts to the Workflow run.

By default, these artifacts are only maintained for 21 days, which is less than the 90 day max for GitHub Free. 21 days was chosen to support ballots in the Discussion period, which time out after three weeks of no action. The workflow can always be re-triggered manually, if necessary.

GitHub uploads all artifacts as `zip` files, so this does mean an extra step to open the zip file to extract the associated `pdf` and `docx`, but that should hopefully be easy.

Redlines are not yet supported in https://github.com/cabforum/build-guidelines-action, so these aren't yet generated.

Compared to the existing Travis-CI integration, the benefit of this approach is that these actions will also, by default, run in repository forks/clones, making it easy for CA/B Forum Members to preview their changes locally.

Note that further action is required to correct the BRs/EVGs/NCSSRs, specifically:
- Move the YAML preamble into the document itself
- Convert the EVGs/NCSSRs to a consistent flavor of Pandoc markdown (mostly around list items and extensions)

However, by landing the tooling first, it makes it easy to preview and verify that changes to address the above are correct.