### PR TITLE
Correction of wrong numbering in markdown - file

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -594,7 +594,7 @@ This section defines the permitted processes and procedures for validating the A
 The CA SHALL confirm that prior to issuance, the CA has validated each Fully-Qualified Domain Name (FQDN) listed in the Certificate as follows:
 
 1.  When the FQDN does not contain "onion" as the rightmost label, the CA SHALL validate the FQDN using at least one of the methods listed below; and
-1.  When the FQDN contains "onion" as the rightmost label, the CA SHALL validate the FQDN in accordance with Appendix B.
+2.  When the FQDN contains "onion" as the rightmost label, the CA SHALL validate the FQDN in accordance with Appendix B.
 
 Completed validations of Applicant authority may be valid for the issuance of multiple Certificates over time. In all cases, the validation must have been initiated within the time period specified in the relevant requirement (such as Section 4.2.1 of this document) prior to Certificate issuance. For purposes of domain validation, the term Applicant includes the Applicant's Parent Company, Subsidiary Company, or Affiliate.
 
@@ -636,8 +636,8 @@ CAs SHALL NOT perform validations using this method after May 31, 2019.  Complet
 
 Confirm the Applicant's control over the FQDN by
 1.  Sending an email to one or more addresses created by using 'admin', 'administrator', 'webmaster', 'hostmaster', or 'postmaster' as the local part, followed by the at-sign ("@"), followed by an Authorization Domain Name; and
-1.  including a Random Value in the email; and
-1.  receiving a confirming response utilizing the Random Value.
+2.  including a Random Value in the email; and
+3.  receiving a confirming response utilizing the Random Value.
 
 Each email MAY confirm control of multiple FQDNs, provided the Authorization Domain Name used in the email is an Authorization Domain Name for each FQDN being confirmed
 


### PR DESCRIPTION
In the raw mark down file there are two places where the numbering of a list is not correct. Interestingly in the rendered version it is correct.