### PR TITLE
Update the SCWG to use a Docker image for CI

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.push.before }}
           path: old/
-      - uses: cabforum/build-guidelines-action@v2.0.1
+      - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.0.2
         id: build_doc
         with:
           markdown_file: docs/${{ matrix.document }}


### PR DESCRIPTION
This moves from using a GitHub Action as a Docker container that is
built on demand to using a public Docker container image hosted on
GitHub Container Registry (GHCR).

Prior to this change, GitHub Workflows check out the Action
repository and build the Docker image on demand for the workflow.
The downside to this is the external dependencies that are loaded
on demand (such as fonts and TeX Live packages) are subject to the
whims of the network gods and solar flares, and thus can result in
failed CI runs or very long (1+ hour) runs.

With this change, this switches to use the Docker image that is
automatically published to GHCR whenever we commit to the
cabforum/build-guidelines-action repository, which has all of the
resources integrated. As this now only depends on GitHub's network,
it's more reliable. As a bonus, it also executes much faster.