### PR TITLE
SC46: Sunset the CAA exception for DNS operator

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -158,6 +158,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as an o
 | 2020-09-30 | 7.1.4.1 | Subject and Issuer Names for all possible certification paths MUST be byte-for-byte identical. |
 | 2020-09-30 | 7.1.6.4 | Subscriber Certificates MUST include a CA/Browser Form Reserved Policy Identifier in the Certificate Policies extension. |
 | 2020-09-30 | 7.2 and 7.3 | All OCSP and CRL responses for Subordinate CA Certificates MUST include a meaningful reason code. |
+| 2021-07-01 | 3.2.2.8 | CAA checking is no longer optional if the CA is the DNS Operator or an Affiliate. |
 
 ## 1.3 PKI Participants
 
@@ -954,7 +955,7 @@ RFC 8659 requires that CAs "MUST NOT issue a certificate unless the CA determine
 
 * CAA checking is optional for certificates for which a Certificate Transparency pre-certificate was created and logged in at least two public logs, and for which CAA was checked.
 * CAA checking is optional for certificates issued by a Technically Constrained Subordinate CA Certificate as set out in [Section 7.1.5](#715-name-constraints), where the lack of CAA checking is an explicit contractual provision in the contract with the Applicant.
-* CAA checking is optional if the CA or an Affiliate of the CA is the DNS Operator (as defined in RFC 7719) of the domain's DNS.
+* For certificates issued prior to July 1, 2021, CAA checking is optional if the CA or an Affiliate of the CA is the DNS Operator (as defined in RFC 7719) of the domain's DNS.
 
 CAs are permitted to treat a record lookup failure as permission to issue if:
 


### PR DESCRIPTION
## Purpose of Ballot

This Ballot addresses security issues with Section 3.2.2.8 regarding CAA checking.

Currently, Section 3.2.2.8 permits a CA to bypass CAA checking if the CA or an Affiliate of the CA is the DNS Operator. This term is referred to through RFC 7719, and involves a precise technical definition regarding how a zone's authoritative servers are configured and expressed (e.g. NS records). While this allows a CA to skip looking up the CAA record, it does not absolve them of the need to look up these other records on every issuance.

As practiced by CAs, this has clearly caused some confusion. For example, some CAs have incorrectly implemented policies that determine they're authoritative based on self-assertion that they are authoritative, which is not consistent with the current requirements.

To avoid these issues, this sunsets the CAA exception on 2021-07-01 for the DNS Operator, simplifying the requirements and reducing ambiguities for CAs performing validation.

The following motion has been proposed by Ryan Sleevi of Google and endorsed by Ben Wilson of Mozilla and Jacob Hoffman-Andrews of ISRG/Let's Encrypt.