### PR TITLE
Remove all trailing spaces and extraneous space before a comma

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -3,7 +3,7 @@ title: Baseline Requirements for the Issuance and Management of Publicly-Trusted
 subtitle: Version 1.7.6
 author:
   - CA/Browser Forum
-date: 3 June, 2021  
+date: 3 June, 2021
 copyright: |
   Copyright 2021 CA/Browser Forum
 
@@ -198,7 +198,7 @@ As defined in [Section 1.6.1](#161-definitions).
 
 ### 1.3.4 Relying Parties
 
-"Relying Party" and "Application Software Supplier" are defined in [Section 1.6.1](#161-definitions). Current Members of the CA/Browser Forum who are Application Software Suppliers are listed here:  
+"Relying Party" and "Application Software Supplier" are defined in [Section 1.6.1](#161-definitions). Current Members of the CA/Browser Forum who are Application Software Suppliers are listed here:
 <https://cabforum.org/members>.
 
 ### 1.3.5 Other Participants
@@ -1042,7 +1042,7 @@ After the change to any validation method specified in the Baseline Requirements
 
 The CA SHALL develop, maintain, and implement documented procedures that identify and require additional verification activity for High Risk Certificate Requests prior to the Certificate's approval, as reasonably necessary to ensure that such requests are properly verified under these Requirements.
 
-If a Delegated Third Party fulfills any of the CA's obligations under this section , the CA SHALL verify that the process used by the Delegated Third Party to identify and further verify High Risk Certificate Requests provides at least the same level of assurance as the CA's own processes.
+If a Delegated Third Party fulfills any of the CA's obligations under this section, the CA SHALL verify that the process used by the Delegated Third Party to identify and further verify High Risk Certificate Requests provides at least the same level of assurance as the CA's own processes.
 
 ### 4.2.2 Approval or rejection of certificate applications
 
@@ -2041,8 +2041,8 @@ Subject attributes MUST NOT contain only metadata such as '.', '-', and ' ' (i.e
 
 ##### 7.1.4.2.1 Subject Alternative Name Extension
 
-__Certificate Field:__ `extensions:subjectAltName`  
-__Required/Optional:__ Required  
+__Certificate Field:__ `extensions:subjectAltName`
+__Required/Optional:__ Required
 __Contents:__ This extension MUST contain at least one entry. Each entry MUST be either a `dNSName` containing the Fully-Qualified Domain Name or an `iPAddress` containing the IP address of a server. The CA MUST confirm that the Applicant controls the Fully-Qualified Domain Name or IP address or has been granted the right to use it by the Domain Name Registrant or IP address assignee, as appropriate.
 
 Wildcard FQDNs are permitted.
@@ -2053,55 +2053,55 @@ Entries in the `dNSName` MUST be in the "preferred name syntax", as specified in
 
 ##### 7.1.4.2.2 Subject Distinguished Name Fields
 
-a. __Certificate Field:__ `subject:commonName` (OID 2.5.4.3)  
-   __Required/Optional:__ __Deprecated__ (Discouraged, but not prohibited)  
+a. __Certificate Field:__ `subject:commonName` (OID 2.5.4.3)
+   __Required/Optional:__ __Deprecated__ (Discouraged, but not prohibited)
    __Contents:__ If present, this field MUST contain a single IP address or Fully-Qualified Domain Name that is one of the values contained in the Certificate's `subjectAltName` extension (see [Section 7.1.4.2.1](#71421-subject-alternative-name-extension)).
 
-b. __Certificate Field:__ `subject:organizationName` (OID 2.5.4.10)  
-   __Required/Optional:__ __Optional__.  
+b. __Certificate Field:__ `subject:organizationName` (OID 2.5.4.10)
+   __Required/Optional:__ __Optional__.
    __Contents:__ If present, the `subject:organizationName` field MUST contain either the Subject's name or DBA as verified under [Section 3.2.2.2](#3222-dbatradename). The CA may include information in this field that differs slightly from the verified name, such as common variations or abbreviations, provided that the CA documents the difference and any abbreviations used are locally accepted abbreviations; e.g., if the official record shows "Company Name Incorporated", the CA MAY use "Company Name Inc." or "Company Name". Because Subject name attributes for individuals (e.g. givenName (2.5.4.42) and surname (2.5.4.4)) are not broadly supported by application software, the CA MAY use the `subject:organizationName` field to convey a natural person Subject's name or DBA.
 
-c. __Certificate Field:__ `subject:givenName` (2.5.4.42) and `subject:surname` (2.5.4.4)  
-   __Required/Optional:__ __Optional__.  
+c. __Certificate Field:__ `subject:givenName` (2.5.4.42) and `subject:surname` (2.5.4.4)
+   __Required/Optional:__ __Optional__.
    __Contents:__ If present, the `subject:givenName` field and `subject:surname` field MUST contain a natural person Subject’s name as verified under [Section 3.2.3](#323-authentication-of-individual-identity). A Certificate containing a `subject:givenName` field or `subject:surname` field MUST contain the (2.23.140.1.2.3) Certificate Policy OID.
 
-d. __Certificate Field:__ Number and street: `subject:streetAddress` (OID: 2.5.4.9)  
-   __Required/Optional:__  
-   __Optional__ if the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are present.  
-   __Prohibited__ if the `subject:organizationName` field, `subject:givenName`, and `subject:surname` field are absent.  
+d. __Certificate Field:__ Number and street: `subject:streetAddress` (OID: 2.5.4.9)
+   __Required/Optional:__
+   __Optional__ if the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are present.
+   __Prohibited__ if the `subject:organizationName` field, `subject:givenName`, and `subject:surname` field are absent.
    __Contents:__ If present, the `subject:streetAddress` field MUST contain the Subject's street address information as verified under [Section 3.2.2.1](#3221-identity).
 
-e. __Certificate Field:__ `subject:localityName` (OID: 2.5.4.7)  
-   __Required/Optional:__  
-   __Required__ if the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are present and the `subject:stateOrProvinceName` field is absent.  
-   __Optional__ if the `subject:stateOrProvinceName` field and the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are present.  
-   __Prohibited__ if the `subject:organizationName` field, `subject:givenName`, and `subject:surname` field are absent.  
+e. __Certificate Field:__ `subject:localityName` (OID: 2.5.4.7)
+   __Required/Optional:__
+   __Required__ if the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are present and the `subject:stateOrProvinceName` field is absent.
+   __Optional__ if the `subject:stateOrProvinceName` field and the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are present.
+   __Prohibited__ if the `subject:organizationName` field, `subject:givenName`, and `subject:surname` field are absent.
    __Contents:__ If present, the `subject:localityName` field MUST contain the Subject's locality information as verified under [Section 3.2.2.1](#3221-identity). If the `subject:countryName` field specifies the ISO 3166-1 user-assigned code of XX in accordance with [Section 7.1.4.2.2](#71422-subject-distinguished-name-fields) (g), the `localityName` field MAY contain the Subject's locality and/or state or province information as verified under [Section 3.2.2.1](#3221-identity).
 
-f. __Certificate Field:__ `subject:stateOrProvinceName` (OID: 2.5.4.8)  
-   __Required/Optional:__  
-   __Required__ if the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are present and `subject:localityName` field is absent.  
-   __Optional__ if the `subject:localityName` field and the `subject:organizationName` field, the `subject:givenName` field, or the `subject:surname` field are present.  
-   __Prohibited__ if the `subject:organizationName` field, the `subject:givenName` field, or `subject:surname` field are absent.  
+f. __Certificate Field:__ `subject:stateOrProvinceName` (OID: 2.5.4.8)
+   __Required/Optional:__
+   __Required__ if the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are present and `subject:localityName` field is absent.
+   __Optional__ if the `subject:localityName` field and the `subject:organizationName` field, the `subject:givenName` field, or the `subject:surname` field are present.
+   __Prohibited__ if the `subject:organizationName` field, the `subject:givenName` field, or `subject:surname` field are absent.
    __Contents:__ If present, the `subject:stateOrProvinceName` field MUST contain the Subject's state or province information as verified under [Section 3.2.2.1](#3221-identity). If the `subject:countryName` field specifies the ISO 3166-1 user-assigned code of XX in accordance with [Section 7.1.4.2.2](#71422-subject-distinguished-name-fields) (g), the `subject:stateOrProvinceName` field MAY contain the full name of the Subject's country information as verified under [Section 3.2.2.1](#3221-identity).
 
-g. __Certificate Field:__ `subject:postalCode` (OID: 2.5.4.17)  
-   __Required/Optional:__  
-   __Optional__ if the `subject:organizationName`, `subject:givenName` field, or `subject:surname` fields are present.  
-   __Prohibited__ if the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are absent.  
+g. __Certificate Field:__ `subject:postalCode` (OID: 2.5.4.17)
+   __Required/Optional:__
+   __Optional__ if the `subject:organizationName`, `subject:givenName` field, or `subject:surname` fields are present.
+   __Prohibited__ if the `subject:organizationName` field, `subject:givenName` field, or `subject:surname` field are absent.
    __Contents:__ If present, the `subject:postalCode` field MUST contain the Subject's zip or postal information as verified under [Section 3.2.2.1](#3221-identity).
 
-h. __Certificate Field:__ `subject:countryName` (OID: 2.5.4.6)  
-   __Required/Optional:__  
-   __Required__ if the `subject:organizationName` field, `subject:givenName`, or `subject:surname` field are present.  
-   __Optional__ if the `subject:organizationName` field, `subject:givenName` field, and `subject:surname` field are absent.  
+h. __Certificate Field:__ `subject:countryName` (OID: 2.5.4.6)
+   __Required/Optional:__
+   __Required__ if the `subject:organizationName` field, `subject:givenName`, or `subject:surname` field are present.
+   __Optional__ if the `subject:organizationName` field, `subject:givenName` field, and `subject:surname` field are absent.
    __Contents:__ If the `subject:organizationName` field is present, the `subject:countryName` MUST contain the two-letter ISO 3166-1 country code associated with the location of the Subject verified under [Section 3.2.2.1](#3221-identity). If the `subject:organizationName` field is absent, the `subject:countryName` field MAY contain the two-letter ISO 3166-1 country code associated with the Subject as verified in accordance with [Section 3.2.2.3](#3223-verification-of-country). If a Country is not represented by an official ISO 3166-1 country code, the CA MAY specify the ISO 3166-1 user-assigned code of XX indicating that an official ISO 3166-1 alpha-2 code has not been assigned.
 
-i. __Certificate Field:__ `subject:organizationalUnitName` (OID: 2.5.4.11)  
-   __Required/Optional:__ __Optional__.  
+i. __Certificate Field:__ `subject:organizationalUnitName` (OID: 2.5.4.11)
+   __Required/Optional:__ __Optional__.
    __Contents__: The CA SHALL implement a process that prevents an OU attribute from including a name, DBA, tradename, trademark, address, location, or other text that refers to a specific natural person or Legal Entity unless the CA has verified this information in accordance with [Section 3.2](#32-initial-identity-validation) and the Certificate also contains `subject:organizationName`, `subject:givenName`, `subject:surname`, `subject:localityName`, and `subject:countryName` attributes, also verified in accordance with [Section 3.2.2.1](#3221-identity).
 
-j. Other Subject Attributes  
+j. Other Subject Attributes
    Other attributes MAY be present within the subject field. If present, other attributes MUST contain information that has been verified by the CA.
 
 #### 7.1.4.3 Subject Information - Root Certificates and Subordinate CA Certificates
@@ -2110,16 +2110,16 @@ By issuing a Subordinate CA Certificate, the CA represents that it followed the 
 
 ##### 7.1.4.3.1 Subject Distinguished Name Fields
 
-a. __Certificate Field:__ `subject:commonName` (OID 2.5.4.3)  
-   __Required/Optional:__ Required  
+a. __Certificate Field:__ `subject:commonName` (OID 2.5.4.3)
+   __Required/Optional:__ Required
    __Contents:__ This field MUST be present and the contents SHOULD be an identifier for the certificate such that the certificate's Name is unique across all certificates issued by the issuing certificate.
 
-b. __Certificate Field:__ `subject:organizationName` (OID 2.5.4.10)  
-   __Required/Optional:__ Required  
+b. __Certificate Field:__ `subject:organizationName` (OID 2.5.4.10)
+   __Required/Optional:__ Required
    __Contents:__ This field MUST be present and the contents MUST contain either the Subject CA's name or DBA as verified under [Section 3.2.2.2](#3222-dbatradename). The CA may include information in this field that differs slightly from the verified name, such as common variations or abbreviations, provided that the CA documents the difference and any abbreviations used are locally accepted abbreviations; e.g., if the official record shows "Company Name Incorporated", the CA MAY use "Company Name Inc." or "Company Name".
 
-c. __Certificate Field:__ `subject:countryName` (OID: 2.5.4.6)  
-   __Required/Optional:__ Required  
+c. __Certificate Field:__ `subject:countryName` (OID: 2.5.4.6)
+   __Required/Optional:__ Required
    __Contents:__ This field MUST contain the two‐letter ISO 3166‐1 country code for the country in which the CA's place of business is located.
 
 ### 7.1.5 Name constraints


### PR DESCRIPTION
Hi,

Thanks for taking a look! I mainly wanted to change the single occurrence of `section ,` to `section,`, but my editor found a ton of trailing whitespace to strip out too.