### PR TITLE
Adjust the workflow file to build the actions

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -1,19 +1,20 @@
 name: Build Draft Guidelines
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   build_docs:
     strategy:
       matrix:
         document:
-          - 'BR.md'
-          - 'EVG.md'
-          - 'NSR.md'
+          - 'BR'
+          - 'EVG'
+          - 'NSR'
     name: Build ${{ matrix.document }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
-      - name: Checkout old version for redline (pull request)
+      - name: Checkout old version for redline
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.push.before }}
@@ -21,18 +22,17 @@ jobs:
       - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.0.2
         id: build_doc
         with:
-          markdown_file: docs/${{ matrix.document }}
-          diff_file: old/docs/${{ matrix.document }}
+          markdown_file: docs/${{ matrix.document }}.md
+          diff_file: old/docs/${{ matrix.document }}.md
           pdf: true
           docx: true
           lint: true
           draft: ${{ !(github.event_name == 'push' && github.repository == 'cabforum/servercert' && github.ref == 'refs/heads/main') }}
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.document }}-${{ github.event.pull_request.head.sha || github.sha }}
+          name: ${{ matrix.document }}-${{ github.event.pull_request.head.sha || github.sha }}-${{ github.event_name }}
           path: |
             ${{ steps.build_doc.outputs.pdf_file }}
             ${{ steps.build_doc.outputs.docx_file }}
             ${{ steps.build_doc.outputs.pdf_redline_file }}
           if-no-files-found: 'error'
-          retention-days: 21


### PR DESCRIPTION
This addresses a few requests that recently came up from the certificate
profiles work:

- Remove the explicit retention period (of 21 days) to allow the GitHub
  default of 90 days.
- Change the generated ZIP file from being "BR.md-hash" to being
  "BR-hash".
- Allow manually invoking the workflow (via workflow_dispatch), in the
  event folks want to re-run for a particular branch (e.g. profiles)
- Attempt to resolve the "non-deterministic redline" noted by Jos. When
  a given commit is on cabforum/servercert, it may be both a commit (to
  a branch) and part of a pull request (to main). We want the pull
  request redline to be against main, while the commit redline to be
  against the previous commit. Because both jobs run, and both upload
  the same file name, this results in a non-deterministic clobbering,
  where the commit-redline may clobber the pr-redline. This changes
  the generated zip file to be "file-hash-event_type", so that it
  will generate redlines for both PRs and commits and attach both.