### PR TITLE
SC47 Sunset subject:organizationalUnitName (with date table fix)

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -1,19 +1,20 @@
 name: Build Draft Guidelines
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   build_docs:
     strategy:
       matrix:
         document:
-          - 'BR.md'
-          - 'EVG.md'
-          - 'NSR.md'
+          - 'BR'
+          - 'EVG'
+          - 'NSR'
     name: Build ${{ matrix.document }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
-      - name: Checkout old version for redline (pull request)
+      - name: Checkout old version for redline
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.push.before }}
@@ -21,18 +22,17 @@ jobs:
       - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.0.2
         id: build_doc
         with:
-          markdown_file: docs/${{ matrix.document }}
-          diff_file: old/docs/${{ matrix.document }}
+          markdown_file: docs/${{ matrix.document }}.md
+          diff_file: old/docs/${{ matrix.document }}.md
           pdf: true
           docx: true
           lint: true
           draft: ${{ !(github.event_name == 'push' && github.repository == 'cabforum/servercert' && github.ref == 'refs/heads/main') }}
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.document }}-${{ github.event.pull_request.head.sha || github.sha }}
+          name: ${{ matrix.document }}-${{ github.event.pull_request.head.sha || github.sha }}-${{ github.event_name }}
           path: |
             ${{ steps.build_doc.outputs.pdf_file }}
             ${{ steps.build_doc.outputs.docx_file }}
             ${{ steps.build_doc.outputs.pdf_redline_file }}
           if-no-files-found: 'error'
-          retention-days: 21

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -166,6 +166,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as an o
 | 2021-07-01 | 3.2.2.8 | CAA checking is no longer optional if the CA is the DNS Operator or an Affiliate. |
 | 2021-07-01 | 3.2.2.4.18 and 3.2.2.4.19 | Redirects MUST be the result of one of the HTTP status code responses defined.  |
 | 2021-12-01 | 3.2.2.4 | CAs MUST NOT use methods 3.2.2.4.6, 3.2.2.4.18, or 3.2.2.4.19 to issue wildcard certificates or with Authorization Domain Names other than the FQDN. |
+| 2022-09-01 | 7.1.4.2.2 | CAs MUST NOT include the organizationalUnitName field in the Subject |
 
 ## 1.3 PKI Participants
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,9 +1,9 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates
-subtitle: Version 1.7.8
+subtitle: Version 1.7.9
 author:
   - CA/Browser Forum
-date: 13 July, 2021  
+date: 16 August, 2021  
 copyright: |
   Copyright 2021 CA/Browser Forum
 
@@ -121,6 +121,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as an o
 | 1.7.6 | SC44 | Clarify Acceptable Status Codes | 30-Apr-2021 | 3-Jun-2021 |
 | 1.7.7 | SC46 | Sunset the CAA Exception for DNS Operator | 2-Jun-2021 | 12-Jul-2021 |
 | 1.7.8 | SC45 | Wildcard Domain Validation | 2-Jun-2021 | 13-Jul-2021 |
+| 1.7.9 | SC47 | Sunset subject:organizationalUnitName | 30-Jun-2021 | 16-Aug-2021 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -2106,7 +2106,8 @@ h. __Certificate Field:__ `subject:countryName` (OID: 2.5.4.6)
    __Contents:__ If the `subject:organizationName` field is present, the `subject:countryName` MUST contain the two-letter ISO 3166-1 country code associated with the location of the Subject verified under [Section 3.2.2.1](#3221-identity). If the `subject:organizationName` field is absent, the `subject:countryName` field MAY contain the two-letter ISO 3166-1 country code associated with the Subject as verified in accordance with [Section 3.2.2.3](#3223-verification-of-country). If a Country is not represented by an official ISO 3166-1 country code, the CA MAY specify the ISO 3166-1 user-assigned code of XX indicating that an official ISO 3166-1 alpha-2 code has not been assigned.
 
 i. __Certificate Field:__ `subject:organizationalUnitName` (OID: 2.5.4.11)  
-   __Required/Optional:__ __Optional__.  
+   __Required/Optional:__ __Deprecated__. 
+   __Prohibited__ if the `subject:organizationName` is absent or the certificate is issued on or after September 1, 2022.
    __Contents__: The CA SHALL implement a process that prevents an OU attribute from including a name, DBA, tradename, trademark, address, location, or other text that refers to a specific natural person or Legal Entity unless the CA has verified this information in accordance with [Section 3.2](#32-initial-identity-validation) and the Certificate also contains `subject:organizationName`, `subject:givenName`, `subject:surname`, `subject:localityName`, and `subject:countryName` attributes, also verified in accordance with [Section 3.2.2.1](#3221-identity).
 
 j. Other Subject Attributes  

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -514,7 +514,7 @@ __Contents__: This field MUST contain the address of the physical location of th
 ### 9.2.7. Subject Organizational Unit Name Field
 
 __Certificate Field__: `subject:organizationalUnitName` (OID: 2.5.4.11)  
-__Required/Optional__: Optional  
+__Required/Optional/Prohibited:__ As stated in Section 7.1.4.2.2 i of the Baseline Requirements. 
 __Contents__: The CA SHALL implement a process that prevents an OU attribute from including a name, DBA, tradename, trademark, address, location, or other text that refers to a specific natural person or Legal Entity unless the CA has verified this information in accordance with [Section 11](#11-verification-requirements). This field MUST NOT contain only metadata such as '.', '-', and ' ' (i.e. space) characters, and/or any other indication that the value is absent, incomplete, or not applicable.
 
 ### 9.2.8. Subject Organization Identifier Field

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1,9 +1,9 @@
 ---
 title: Guidelines for the Issuance and Management of Extended Validation Certificates
-subtitle: Version 1.7.6
+subtitle: Version 1.7.7
 author:
   - CA/Browser Forum
-date: 2 June, 2021
+date: 16 August, 2021
 copyright: |
   Copyright 2021 CA/Browser Forum
 
@@ -68,6 +68,7 @@ The CA/Browser Forum is a voluntary open organization of certification authoriti
 | 1.7.4 | SC35 | Cleanups and Clarifications | 9-Sep-2020 | 19-Oct-2020 |
 | 1.7.5 | SC41 | Reformatting the BRs, EVGs, and NCSSRs | 24-Feb-2021 | 5-Apr-2021 |
 | 1.7.6 | SC42 | 398-day Re-use Period | 22-Apr-2021 | 2-Jun-2021 |
+| 1.7.7 | SC47 | Sunset subject:organizationalUnitName | 30-Jun-2021 | 16-Aug-2021 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 


### PR DESCRIPTION
* Deprecation of subject:organizationalUnitName
* Update language to avoid confusion on the effective date

This version updates SC47 to state "issued on or after September 1, 2022" and makes the EV Guidelines reference the BRs as suggested by Ryan Sleevi from Google.

Co-authored-by: Ryan Sleevi ryan.sleevi@gmail.com
