### PR TITLE
Ballot SC50 - Remove the requirements of 4.1.1

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,9 +1,9 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates
-subtitle: Version 1.8.0
+subtitle: Version 1.8.1
 author:
   - CA/Browser Forum
-date: 25 August, 2021  
+date: 23 December, 2021  
 copyright: |
   Copyright 2021 CA/Browser Forum
 
@@ -123,6 +123,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as an o
 | 1.7.8 | SC45 | Wildcard Domain Validation | 2-Jun-2021 | 13-Jul-2021 |
 | 1.7.9 | SC47 | Sunset subject:organizationalUnitName | 30-Jun-2021 | 16-Aug-2021 |
 | 1.8.0 | SC48 | Domain Name and IP Address Encoding | 22-Jul-2021 | 25-Aug-2021 |
+| 1.8.1 | SC50 | Remove the requirements of 4.1.1 | 22-Nov-2021 | 23-Dec-2021 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1044,7 +1044,7 @@ The CA SHALL disclose all Cross Certificates that identify the CA as the Subject
 
 ### 4.1.1 Who can submit a certificate application
 
-In accordance with [Section 5.5.2](#552-retention-period-for-archive), the CA SHALL maintain an internal database of all previously revoked Certificates and previously rejected certificate requests due to suspected phishing or other fraudulent usage or concerns. The CA SHALL use this information to identify subsequent suspicious certificate requests.
+No stipulation.
 
 ### 4.1.2 Enrollment process and responsibilities
 


### PR DESCRIPTION
# BALLOT SC50: Remove the requirements of 4.1.1 #

## PURPOSE OF BALLOT ##

When attempting to reduce the retention period required for audit logs and data archives, the NetSec Subcommittee also identified gaps in which data a CA is required to retain which make it somewhat difficult to make the desired adjustments to retention period. Specifically, a CA is currently required to retain, but not use, data as defined in 4.1.1 of the BRs.
While reviewing the intent, purpose, and real-world usage around section 4.1.1, it became apparent that there’s little value in requiring CAs to maintain a database for which there is no prescribed purpose or required action. This ballot seeks to address this gap by replacing section 4.1.1 with "No stipulation." as is appropriate based on current expectations here.

The following motion has been proposed by Clint Wilson of Apple and endorsed by Trevoli Ponds-White of Amazon and Dustin Hollenback of Microsoft.