### PR TITLE
Ballot SC54: Onion Cleanup

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,9 +1,9 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates
-subtitle: Version 1.8.3
+subtitle: Version 1.8.4
 author:
   - CA/Browser Forum
-date: 15 April, 2022  
+date: 23 April, 2022  
 copyright: |
   Copyright 2022 CA/Browser Forum
 
@@ -125,7 +125,8 @@ The following Certificate Policy identifiers are reserved for use by CAs as an o
 | 1.8.0 | SC48 | Domain Name and IP Address Encoding | 22-Jul-2021 | 25-Aug-2021 |
 | 1.8.1 | SC50 | Remove the requirements of 4.1.1 | 22-Nov-2021 | 23-Dec-2021 |
 | 1.8.2 | SC53 | Sunset for SHA-1 OCSP Signing | 26-Jan-2022 | 4-Mar-2022 |
-| 1.8.3 | SC51 | Reduce and Clarify Log and Records Archival Retention Requirements | 01-Mar-2021 | 15-Apr-2022 |
+| 1.8.3 | SC51 | Reduce and Clarify Log and Records Archival Retention Requirements | 01-Mar-2022 | 15-Apr-2022 |
+| 1.8.4 | SC54 | Onion Cleanup | 24-Mar-2022 | 23-Apr-2022 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -371,6 +371,8 @@ The Definitions found in the CA/Browser Forum's Network and Certificate System S
 
 **OCSP Responder**: An online server operated under the authority of the CA and connected to its Repository for processing Certificate status requests. See also, Online Certificate Status Protocol.
 
+**Onion Domain Name**: A Fully Qualified Domain Name ending with the RFC 7686 ".onion" Special-Use Domain Name. For example, `2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion` is an Onion Domain Name, whereas `torproject.org` is not an Onion Domain Name.
+
 **Online Certificate Status Protocol**: An online Certificate-checking protocol that enables relying-party application software to determine the status of an identified Certificate. See also OCSP Responder.
 
 **Parent Company**: A company that Controls a Subsidiary Company.
@@ -677,8 +679,8 @@ This section defines the permitted processes and procedures for validating the A
 
 The CA SHALL confirm that prior to issuance, the CA has validated each Fully-Qualified Domain Name (FQDN) listed in the Certificate as follows:
 
-1. When the FQDN does not contain "onion" as the rightmost Domain Label, the CA SHALL validate the FQDN using at least one of the methods listed below; and
-2. When the FQDN contains "onion" as the rightmost Domain Label, the CA SHALL validate the FQDN in accordance with Appendix B.
+1. When the FQDN is not an Onion Domain Name, the CA SHALL validate the FQDN using at least one of the methods listed below; and
+2. When the FQDN is an Onion Domain Name, the CA SHALL validate the FQDN in accordance with Appendix B.
 
 Completed validations of Applicant authority may be valid for the issuance of multiple Certificates over time. In all cases, the validation must have been initiated within the time period specified in the relevant requirement (such as [Section 4.2.1](#421-performing-identification-and-authentication-functions) of this document) prior to Certificate issuance. For purposes of domain validation, the term Applicant includes the Applicant's Parent Company, Subsidiary Company, or Affiliate.
 
@@ -992,7 +994,7 @@ Databases maintained by the CA, its owner, or its affiliated companies do not qu
 
 #### 3.2.2.8 CAA Records
 
-As part of the issuance process, the CA MUST check for CAA records and follow the processing instructions found, for each `dNSName` in the `subjectAltName` extension of the certificate to be issued, as specified in RFC 8659. If the CA issues, they MUST do so within the TTL of the CAA record, or 8 hours, whichever is greater.
+As part of the Certificate issuance process, the CA MUST retrieve and process CAA records in accordance with RFC 8659 for each `dNSName` in the `subjectAltName` extension that does not contain an Onion Domain Name. If the CA issues, they MUST do so within the TTL of the CAA record, or 8 hours, whichever is greater.
 
 This stipulation does not prevent the CA from checking CAA records at any other time.
 
@@ -2633,32 +2635,34 @@ The DNS TXT record MUST be placed on the "`_validation-contactemail`" subdomain 
 
 The DNS TXT record MUST be placed on the "`_validation-contactphone`" subdomain of the domain being validated. The entire RDATA value of this TXT record MUST be a valid Global Number as defined in RFC 3966, Section 5.1.4, or it cannot be used.
 
-# APPENDIX B – Issuance of Certificates for .onion Domain Names
+# APPENDIX B – Issuance of Certificates for Onion Domain Names
 
-This appendix defines permissible verification procedures for including one or more RFC 7686 ".onion" special-use Domain Names in a Certificate.
+This appendix defines permissible verification procedures for including one or more Onion Domain Names in a Certificate.
 
-1. The Domain Name MUST contain at least two Domain Labels, where the right-most Domain Label is "onion", and the Domain Label immediately preceding the right-most "onion" Domain Label is a valid Version 3 Onion Address, as defined in Section 6 of the Tor Rendezvous Specification - Version 3 located at <https://spec.torproject.org/rend-spec-v3>.
+1. The Domain Name MUST contain at least two Domain Labels, where the rightmost Domain Label is "onion", and the Domain Label immediately preceding the rightmost "onion" Domain Label is a valid Version 3 Onion Address, as defined in Section 6 of the Tor Rendezvous Specification - Version 3 located at <https://spec.torproject.org/rend-spec-v3>.
 
-2. The CA MUST verify the Applicant’s control over the .onion Domain Name using at least one of the methods listed below:
+2. The CA MUST verify the Applicant’s control over the Onion Domain Name using at least one of the methods listed below:
 
    a. The CA MAY verify the Applicant's control over the .onion service by using one of the following methods from [Section 3.2.2.4](#3224-validation-of-domain-authorization-or-control):
 
-      i. [Section 3.2.2.4.6 - Agreed-Upon Change to Website](#32246-agreed-upon-change-to-website)
-      ii. [Section 3.2.2.4.18 - Agreed-Upon Change to Website v2](#322418-agreed-upon-change-to-website-v2)
-      iii. [Section 3.2.2.4.19 - Agreed-Upon Change to Website - ACME](#322419-agreed-upon-change-to-website-acme)
+      i. [Section 3.2.2.4.18 - Agreed-Upon Change to Website v2](#322418-agreed-upon-change-to-website-v2)
+      ii. [Section 3.2.2.4.19 - Agreed-Upon Change to Website - ACME](#322419-agreed-upon-change-to-website-acme)
+      iii. [Section 3.2.2.4.20 - TLS Using ALPN](#322420-tls-using-alpn)
 
       When these methods are used to verify the Applicant's control over the .onion service, the CA MUST use Tor protocol to establish a connection to the .onion hidden service. The CA MUST NOT delegate or rely on a third-party to establish the connection, such as by using Tor2Web.
 
       **Note**: This section does not override or supersede any provisions specified within the respective methods. The CA MUST only use a method if it is still permitted within that section and MUST NOT issue Wildcard Certificates or use it as an Authorization Domain Name, except as specified by that method.
 
-   b. The CA MAY verify the Applicant's control over the .onion service by having the Applicant provide a Certificate Request signed using the .onion public key if the Attributes section of the certificationRequestInfo contains:
+   b. The CA MAY verify the Applicant's control over the .onion service by having the Applicant provide a Certificate Request signed using the .onion service's private key if the Attributes section of the certificationRequestInfo contains:
 
       i. A caSigningNonce attribute that contains a Random Value that is generated by the CA; and
-      ii. An applicantSigningNonce attribute that contains a single value with at least 64-bits of entropy that is generated by the Applicant.
+      ii. An applicantSigningNonce attribute that contains a single value. The CA MUST recommend to Applicants that the applicantSigningNonce value should contain at least 64 bits of entropy.
 
       The signing nonce attributes have the following format:
 
       ```ASN.1
+      cabf OBJECT IDENTIFIER ::= { joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) }
+
       caSigningNonce ATTRIBUTE ::= {
          WITH SYNTAX              OCTET STRING
          EQUALITY MATCHING RULE   octetStringMatch
@@ -2682,4 +2686,4 @@ This appendix defines permissible verification procedures for including one or m
 
       Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
-3. When a Certificate includes an FQDN where "onion" is the right-most Domain Label of the Domain Name, the Domain Name shall not be considered an Internal Name provided that the Certificate was issued in compliance with this [Appendix B](#appendix-b--issuance-of-certificates-for-onion-domain-names).
+3. When a Certificate includes an Onion Domain Name, the Domain Name shall not be considered an Internal Name provided that the Certificate was issued in compliance with this [Appendix B](#appendix-b--issuance-of-certificates-for-onion-domain-names).

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1,11 +1,11 @@
 ---
 title: Guidelines for the Issuance and Management of Extended Validation Certificates
-subtitle: Version 1.7.8
+subtitle: Version 1.7.9
 author:
   - CA/Browser Forum
-date: 25 August, 2021
+date: 23 April, 2022
 copyright: |
-  Copyright 2021 CA/Browser Forum
+  Copyright 2022 CA/Browser Forum
 
   This work is licensed under the Creative Commons Attribution 4.0 International license.
 ---
@@ -70,6 +70,7 @@ The CA/Browser Forum is a voluntary open organization of certification authoriti
 | 1.7.6 | SC42 | 398-day Re-use Period | 22-Apr-2021 | 2-Jun-2021 |
 | 1.7.7 | SC47 | Sunset subject:organizationalUnitName | 30-Jun-2021 | 16-Aug-2021 |
 | 1.7.8 | SC48 | Domain Name and IP Address Encoding | 22-Jul-2021 | 25-Aug-2021 |
+| 1.7.9 | SC54 | Onion Cleanup | 24-Mar-2022 | 23-Apr-2022 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -465,7 +465,7 @@ If the combination of names or the organization name by itself exceeds 64 charac
 
 __Certificate Field__: `subject:commonName` (OID: 2.5.4.3)  
 __Required/Optional__: Deprecated (Discouraged, but not prohibited)  
-__Contents__: If present, this field MUST contain a single Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service).  Wildcard certificates are not allowed for EV Certificates except as permitted under [Appendix F](#appendix-f--issuance-of-certificates-for-onion-domain-names).
+__Contents__: If present, this field MUST contain a single Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service). This field MUST NOT contain a Wildcard Domain Name unless the FQDN portion of the Wildcard Domain Name is an Onion Domain Name verified in accordance with Appendix B of the Baseline Requirements.
 
 ### 9.2.3. Subject Business Category Field
 
@@ -649,7 +649,7 @@ If a CA includes an extension in a certificate that has a Certificate field whic
 
 __Certificate Field__: `subjectAltName:dNSName`  
 __Required/Optional__: __Required__  
-__Contents__: This extension MUST contain one or more host Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service).  Wildcard certificates are not allowed for EV Certificates.
+__Contents__: This extension MUST contain one or more host Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service). This extension MUST NOT contain a Wildcard Domain Name unless the FQDN portion of the Wildcard Domain Name is an Onion Domain Name verified in accordance with Appendix B of the Baseline Requirements.
 
 ### 9.8.2. CA/Browser Forum Organization Identifier Extension
 
@@ -959,7 +959,7 @@ To verify the Applicant's ability to engage in business, the CA MUST verify the 
 
 ### 11.7.1. Verification Requirements
 
-1. For each Fully-Qualified Domain Name listed in a Certificate, other than a Domain Name with "onion" as the right-most Domain Label of the Domain Name, the CA SHALL confirm that, as of the date the Certificate was issued, the Applicant (or the Applicant's Parent Company, Subsidiary Company, or Affiliate, collectively referred to as "Applicant" for the purposes of this section)  either is the Domain Name Registrant or has control over the FQDN using a procedure specified in Section 3.2.2.4 of the Baseline Requirements.  For a Certificate issued to a Domain Name with "onion" as the right-most Domain Label of the Domain Name, the CA SHALL confirm that, as of the date the Certificate was issued, the Applicant's control over the .onion Domain Name in accordance with [Appendix F](#appendix-f--issuance-of-certificates-for-onion-domain-names).
+1. For each Fully-Qualified Domain Name listed in a Certificate which is not an Onion Domain Name, the CA SHALL confirm that, as of the date the Certificate was issued, the Applicant (or the Applicant's Parent Company, Subsidiary Company, or Affiliate, collectively referred to as "Applicant" for the purposes of this section) either is the Domain Name Registrant or has control over the FQDN using a procedure specified in Section 3.2.2.4 of the Baseline Requirements. For a Certificate issued to an Onion Domain Name, the CA SHALL confirm that, as of the date the Certificate was issued, the Applicant's control over the Onion Domain Name in accordance with Appendix B of the Baseline Requirements.
 
 2. **Mixed Character Set Domain Names**: EV Certificates MAY include Domain Names containing mixed character sets only in compliance with the rules set forth by the domain registrar.  The CA MUST visually compare any Domain Names with mixed character sets with known high risk domains.  If a similarity is found, then the EV Certificate Request MUST be flagged as High Risk.  The CA must perform reasonably appropriate additional authentication and verification to be certain beyond reasonable doubt that the Applicant and the target in question are the same organization.
 
@@ -1640,75 +1640,9 @@ A CA may rely on the Contract Signer's authority to enter into the Subscriber Ag
    ii. is expressly authorized by [Applicant name] to sign Subscriber Agreements and approve EV Certificate requests on Applicant's behalf, and
    iii. has confirmed Applicant's right to use the domain(s) to be included in EV Certificates.
 
-# Appendix F – Issuance of Certificates for .onion Domain Names
+# Appendix F – Unused
 
-A CA may issue an EV Certificate with "onion" as the right-most Domain Label of the Domain Name provided that issuance complies with the requirements set forth in this Appendix or Appendix C of the Baseline Requirements.
-
-1. CAB Forum Tor Service Descriptor Hash extension (2.23.140.1.31)
-
-   The CA MUST include the CAB Forum Tor Service Descriptor Hash extension in the `TBSCertificate` to convey hashes of keys related to .onion addresses. The CA MUST include the Tor Service Descriptor Hash extension using the following format:
-
-   ```ASN.1
-   cabf-TorServiceDescriptor OBJECT IDENTIFIER ::= { 2.23.140.1.31 }
-
-   TorServiceDescriptorSyntax ::=
-       SEQUENCE (1..MAX) of TorServiceDescriptorHash
-
-   TorServiceDescriptorHash:: = SEQUENCE {
-       onionURI             UTF8String,
-       algorithm            AlgorithmIdentifier,
-       subjectPublicKeyHash BIT STRING
-   }
-   ```
-
-   Where the `AlgorithmIdentifier` is a hashing algorithm (defined in RFC 6234) performed over the DER-encoding of an ASN.1 `subjectPublicKey` of the .onion service and `subjectPublicKeyHash` is the hash output.
-
-2. The CA MUST verify the Applicant's control over the .onion Domain Name using one of the following:
-
-   a. The CA MAY verify the Applicant's control over the .onion service by posting a specific value at a well-known URL under RFC5785.
-
-   b. The CA MAY verify the Applicant's control over the .onion service by having the Applicant provide a Certificate Request signed using the .onion public key if the `Attributes` section of the `certificationRequestInfo` contains:
-
-      i. A `caSigningNonce` attribute that:
-
-         1. contains a single value with at least 64-bits of entropy,
-         2. is generated by the CA, and
-         3. delivered to the Applicant through a Verified Method of Communication and
-
-      ii. An `applicantSigningNonce` attribute that:
-
-          1. contains a single value with at least 64-bits of entropy and 
-          2. is generated by the Applicant.
-
-      The signing nonce attributes have the following format:
-
-      ```ASN.1
-      caSigningNonce ATTRIBUTE ::= {
-          WITH SYNTAX              OCTET STRING
-          EQUALITY MATCHING RULE   octetStringMatch
-          SINGLE VALUE             TRUE
-          ID                       { cabf-caSigningNonce }
-      }
-
-      cabf-caSigningNonce OBJECT IDENTIFIER ::= { cabf 41 }
-
-      applicantSigningNonce ATTRIBUTE ::= {
-          WITH SYNTAX              OCTET STRING
-          EQUALITY MATCHING RULE   octetStringMatch
-          SINGLE VALUE             TRUE
-          ID                       { cabf-applicantSigningNonce }
-      }
-
-      cabf-applicantSigningNonce OBJECT IDENTIFIER ::= { cabf 42 }
-      ```
-
-3. Each Certificate that includes a Domain Name where "onion" is the right-most Domain Label of the Domain Name MUST conform to the requirements of these Guidelines, including the content requirements in Section 7.1 of the Baseline Requirements, except that the CA MAY include a wildcard character in the Subject Alternative Name Extension and Subject Common Name Field as the left-most character in the .onion Domain Name provided inclusion of the wildcard character complies with Section 3.2.2.6 of the Baseline Requirements.
-
-4. CAs MUST NOT issue a Certificate that includes a Domain Name where "onion" is the right-most Domain Label of the Domain Name with a Validity Period longer than 15 months. Effective 2020-09-01, CAs MUST NOT issue a Certificate that includes a Domain Name where "onion" is the right-most Domain Label of the Domain Name with a Validity Period longer than 398 days.
-
-5. When a Certificate that includes a Domain Name where "onion" is the right-most Domain Label of the Domain Name, the Domain Name shall not be considered an Internal Name if the Certificate was issued in compliance with this [Appendix F](#appendix-f--issuance-of-certificates-for-onion-domain-names).
-
-6. On or before May 1, 2015, each CA MUST revoke all Certificates issued with the Subject Alternative Name extension or Common Name field that includes a Domain Name where "onion" is the right-most Domain Label of the Domain Name unless the Certificate was issued in compliance with this [Appendix F](#appendix-f--issuance-of-certificates-for-onion-domain-names).
+This appendix is intentionally left blank.
 
 # Appendix G – Abstract Syntax Notation One module for EV certificates
 


### PR DESCRIPTION
# PURPOSE OF BALLOT

Over the years the Server Certificate WG captured several minor cleanup issues related to Onion Certificates.

Here is a summary of the changes:

  * Created a Defined Term for Onion Domain Name. We discovered a lot of repeated long text describing what an onion certificate is, and thought it would be best adding as a definition

  * Removed EVG Appendix F contents since v2 onion certificates can't be used anymore; it is kept as a placeholder

  * Removed the obligation for the CA to ensure that the applicantSigningNonce includes specific entropy.

  * Tweaked 3.2.2.8 a bit in the hopes of making the initial sentence shorter and easier to read.

The following motion has been proposed by Dimitris Zacharopoulos of HARICA and endorsed by Ben Wilson of Mozilla and Corey Bonnell of DigiCert.

**MOTION BEGINS**

This ballot modifies the “Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates” (“Baseline Requirements”), based on Version 1.8.1:
MODIFY the Baseline Requirements as specified in the following redline:

[https://github.com/cabforum/servercert/compare/65e80e07855ecc1d2264c040ecc7d398f997d2c5...13220d81c0001f79ffa239a00018aa5c556e9afd]

This ballot modifies the “Guidelines for the Issuance and Management of Extended Validation Certificates” (“EV Guidelines”), based on Version 1.7.8: MODIFY the EV Guidelines as defined in the following redline:

[https://github.com/cabforum/servercert/compare/cda0f92ee70121fd5d692685b97ebb6669c74fb7...13220d81c0001f79ffa239a00018aa5c556e9afd]

**MOTION ENDS**

This ballot proposes a Final Maintenance Guideline. The procedure for approval of this ballot is as follows:

**Discussion (7+ days)**

Start Time: 2022-03-08 19:00:00 UTC
End Time: Not before 2022-03-15 19:00:00 UTC

**Vote for approval (7 days)**

Start Time: 2022-03-16 07:00:00 UTC
End Time: 2022-03-23 07:00:00 UTC