### PR TITLE
Update policyQualifiers for CA profiles to MAY

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -2034,7 +2034,7 @@ Table: No Policy Restrictions (Affiliated CA)
 | ---                 | -               | ------       |
 | `policyIdentifier`  | MUST            | When the Issuing CA wishes to express that there are no policy restrictions, the Subordinate CA MUST be an Affiliate of the Issuing CA. The Certificate Policies extension MUST contain only a single `PolicyInformation` value, which MUST contain the `anyPolicy` Policy Identifier. |
 | \ \ \ \ `anyPolicy` | MUST            | |
-| `policyQualifiers`  | NOT RECOMMENDED | If present, MUST contain only permitted `policyQualifiers` from the table below. |
+| `policyQualifiers`  | MAY             | If present, MUST contain only permitted `policyQualifiers` from the table below. |
 
 
 Table: Policy Restricted
@@ -2045,14 +2045,14 @@ Table: Policy Restricted
 | \ \ \ \ A [Reserved Certificate Policy Identifier](#7161-reserved-certificate-policy-identifiers) | MUST NOT | |
 | \ \ \ \ `anyPolicy`          | MUST NOT        | The `anyPolicy` Policy Identifier MUST NOT be present. |
 | \ \ \ \ Any other identifier | MAY             | If present, MUST be documented by the CA in its Certificate Policy and/or Certification Practice Statement. |
-| `policyQualifiers`           | NOT RECOMMENDED | If present, MUST contain only permitted `policyQualifiers` from the table below. |
+| `policyQualifiers`           | MAY             | If present, MUST contain only permitted `policyQualifiers` from the table below. |
 
 
 Table: Permitted `policyQualifiers`
 
 | __Qualifier ID__                     | __Presence__ | __Field Type__ |  __Contents__ |
 | ---                                  | -            | -              | -----         |
-| `id-qt-cps` (OID: 1.3.6.1.5.5.7.2.1) | MAY          | `IA5String`    | The HTTP or HTTPS URL for the Issuing CA's Certificate Policies, Certification Practice Statement, Relying Party Agreement, or other pointer to online policy information provided by the Issuing CA. |
+| `id-qt-cps` (OID: 1.3.6.1.5.5.7.2.1) | MAY          | `IA5String`    | The HTTP or HTTPS URL for the Certificate Policies, Certification Practice Statement, Relying Party Agreement, or other pointer to online policy information provided by the CA or its Issuing CA. |
 | Any other qualifier                  | MUST NOT     | -              | -             |
 
 
@@ -2768,7 +2768,7 @@ Table: No Policy Restrictions (Affiliated CA)
 | ---                 | -               | ------       |
 | `policyIdentifier`  | MUST            | When the Issuing CA wishes to express that there are no policy restrictions, the Subordinate CA MUST be an Affiliate of the Issuing CA. The Certificate Policies extension MUST contain only a single `PolicyInformation` value, which MUST contain the `anyPolicy` Policy Identifier. |
 | \ \ \ \ `anyPolicy` | MUST            | |
-| `policyQualifiers`  | NOT RECOMMENDED | If present, MUST contain only permitted `policyQualifiers` from the table below. |
+| `policyQualifiers`  | MAY             | If present, MUST contain only permitted `policyQualifiers` from the table below. |
 
 
 Table: Policy Restricted
@@ -2779,7 +2779,7 @@ Table: Policy Restricted
 | \ \ \ \ A [Reserved Certificate Policy Identifier](#7161-reserved-certificate-policy-identifiers) | MUST | The CA MUST include at least one Reserved Certificate Policy Identifier (see [Section 7.1.6.1](#7161-reserved-certificate-policy-identifiers)) associated with the given Subscriber Certificate type (see [Section 7.1.2.7.1](#71271-subscriber-certificate-types)) directly or transitively issued by this Certificate. |
 | \ \ \ \ `anyPolicy`          | MUST NOT        | The `anyPolicy` Policy Identifier MUST NOT be present. |
 | \ \ \ \ Any other identifier | MAY             | If present, MUST be defined by the CA and documented by the CA in its Certificate Policy and/or Certification Practice Statement. |
-| `policyQualifiers`           | NOT RECOMMENDED | If present, MUST contain only permitted `policyQualifiers` from the table below. |
+| `policyQualifiers`           | MAY             | If present, MUST contain only permitted `policyQualifiers` from the table below. |
 
 
 This Profile RECOMMENDS that the first `PolicyInformation` value within the Certificate Policies extension contains the Reserved Certificate Policy Identifier (see [7.1.6.1](#7161-reserved-certificate-policy-identifiers))[^first_policy_note]. Regardless of the order of `PolicyInformation` values, the Certificate Policies extension MUST contain exactly one Reserved Certificate Policy Identifier.
@@ -2792,7 +2792,7 @@ Table: Permitted `policyQualifiers`
 
 | __Qualifier ID__                     | __Presence__ | __Field Type__ |  __Contents__ |
 | ---                                  | -            | -              | -----         |
-| `id-qt-cps` (OID: 1.3.6.1.5.5.7.2.1) | MAY          | `IA5String`    | The HTTP or HTTPS URL for the Issuing CA's Certificate Policies, Certification Practice Statement, Relying Party Agreement, or other pointer to online policy information provided by the Issuing CA. |
+| `id-qt-cps` (OID: 1.3.6.1.5.5.7.2.1) | MAY          | `IA5String`    | The HTTP or HTTPS URL for the Certificate Policies, Certification Practice Statement, Relying Party Agreement, or other pointer to online policy information provided by the CA or its Issuing CA. |
 | Any other qualifier                  | MUST NOT     | -              | -             |
 
 ##### 7.1.2.10.6 Extended Key Usage


### PR DESCRIPTION
A compromise was agreed to change the `policyQualifiers` to a `MAY` for CA certificates but keep this `NOT RECOMMENDED` for subscriber certificates.

This pull request updates the presence from `NOT RECOMMENDED` to `MAY` and clarifies the applicability of the `id-qt-cps` qualifier in the following sections:
- 7.1.2.3.2 Certificate Policies (Technically Constrained Non-TLS Subordinate CA Certificate Profile)
- 7.1.2.10.5 Certificate Policies (Common CA Fields)