### PR TITLE
Allow VATEL for organizationIdentifier

### DIFF
--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1704,7 +1704,7 @@ The following Registration Schemes are currently recognized as valid under these
 * **VAT**:
 
   Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in
-  [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field).
+  [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). For the purpose of identifying the country, especially for the "VAT" Registration Scheme, Greece MAY use the prefix "EL".
 
 * **PSD**:
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1700,8 +1700,7 @@ The following Registration Schemes are currently recognized as valid under these
 
 * **VAT**:
 
-  Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in
-  [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). For the purpose of identifying the country, especially for the "VAT" Registration Scheme, Greece MAY use the prefix "EL".
+  Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). For the purpose of identifying the country, especially for the "VAT" Registration Scheme, Greece MAY use the prefix "EL".
 
 * **PSD**:
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -531,7 +531,7 @@ The Registration Scheme MUST be identified using the using the following structu
 * a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8));
 * Registration Reference allocated in accordance with the identified Registration Scheme
 
-Note: Registration References MAY contain hyphens, but Registration Schemes, ISO 3166 country codes, and ISO 3166-2 identifiers do not.  Therefore if more than one hyphen appears in the structure, the leftmost hyphen is a separator, and the remaining hyphens are part of the Registration Reference.
+Note: Registration References MAY contain hyphens, but Registration Schemes, ISO 3166 country codes, and ISO 3166-2 identifiers do not. Therefore if more than one hyphen appears in the structure, the leftmost hyphen is a separator, and the remaining hyphens are part of the Registration Reference.
 
 As in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field), the specified location information MUST match the scope of the registration being referenced.
 
@@ -1716,7 +1716,7 @@ guidelines:
   authority against the organization as identified by the Subject Organization
   Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and
   Subject Registration Number Field (see
-  Section 9.2.5](#925-subject-registration-number-field)) within the context of
+  [Section 9.2.5](#925-subject-registration-number-field)) within the context of
   the subject’s jurisdiction as specified in
   [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field).
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1692,49 +1692,20 @@ END
 
 # Appendix H – Registration Schemes
 
-The following Registration Schemes are currently recognized as valid under these
-guidelines:
+The following Registration Schemes are currently recognized as valid under these guidelines:
 
 * **NTR**:
 
-  The information carried in this field shall be the same as held in
-  Subject Registration Number Field as specified in
-  [Section 9.2.5](#925-subject-registration-number-field) and the country code
-  used in the Registration Scheme identifier shall match that of the
-  subject’s jurisdiction as specified in
+  The information carried in this field shall be the same as held in Subject Registration Number Field as specified in [Section 9.2.5](#925-subject-registration-number-field) and the country code used in the Registration Scheme identifier shall match that of the subject’s jurisdiction as specified in
   [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field).
 
-  Where the Subject Jurisdiction of Incorporation or Registration Field in 9.2.4
-  includes more than the country code, the additional locality information shall
-  be included as specified in [Section 9.2.8](#928-subject-organization-identifier-field)
-  and/or [Section 9.8.2](#982-cabrowser-forum-organization-identifier-extension).
+  Where the Subject Jurisdiction of Incorporation or Registration Field in 9.2.4 includes more than the country code, the additional locality information shall be included as specified in [Section 9.2.8](#928-subject-organization-identifier-field) and/or [Section 9.8.2](#982-cabrowser-forum-organization-identifier-extension).
 
 * **VAT**:
 
-  Reference allocated by the national tax authorities to a Legal Entity. This
-  information shall be validated using information provided by the national tax
-  authority against the organization as identified by the Subject Organization
-  Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and
-  Subject Registration Number Field (see
-  [Section 9.2.5](#925-subject-registration-number-field)) within the context of
-  the subject’s jurisdiction as specified in
+  Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in
   [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field).
 
 * **PSD**:
 
-  Authorization number as specified in ETSI TS 119 495 clause 4.4
-  allocated to a payment service provider and containing the information as
-  specified in ETSI TS 119 495 clause 5.2.1.  This information SHALL be
-  obtained directly from the national competent authority register for
-  payment services or from an information source approved by a government
-  agency, regulatory body, or legislation for this purpose.  This information
-  SHALL be validated by being matched directly or indirectly (for example, by
-  matching a globally unique registration number) against the organization as
-  identified by the Subject Organization Name Field (see
-  [Section 9.2.1](#921-subject-organization-name-field)) and
-  Subject Registration Number Field (see
-  [Section 9.2.5](#925-subject-registration-number-field)) within the context of
-  the subject’s jurisdiction as specified in
-  [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field).
-  The stated address of the organization combined with the organization name
-  SHALL NOT be the only information used to disambiguate the organization.
+  Authorization number as specified in ETSI TS 119 495 clause 4.4 allocated to a payment service provider and containing the information as specified in ETSI TS 119 495 clause 5.2.1. This information SHALL be obtained directly from the national competent authority register for payment services or from an information source approved by a government agency, regulatory body, or legislation for this purpose. This information SHALL be validated by being matched directly or indirectly (for example, by matching a globally unique registration number) against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). The stated address of the organization combined with the organization name SHALL NOT be the only information used to disambiguate the organization.

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1696,10 +1696,7 @@ The following Registration Schemes are currently recognized as valid under these
 
 * **NTR**:
 
-  The information carried in this field shall be the same as held in Subject Registration Number Field as specified in [Section 9.2.5](#925-subject-registration-number-field) and the country code used in the Registration Scheme identifier shall match that of the subject’s jurisdiction as specified in
-  [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field).
-
-  Where the Subject Jurisdiction of Incorporation or Registration Field in 9.2.4 includes more than the country code, the additional locality information shall be included as specified in [Section 9.2.8](#928-subject-organization-identifier-field) and/or [Section 9.8.2](#982-cabrowser-forum-organization-identifier-extension).
+  The information carried in this field shall be the same as held in Subject Registration Number Field as specified in [Section 9.2.5](#925-subject-registration-number-field) and the country code used in the Registration Scheme identifier shall match that of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). Where the Subject Jurisdiction of Incorporation or Registration Field in 9.2.4 includes more than the country code, the additional locality information shall be included as specified in [Section 9.2.8](#928-subject-organization-identifier-field) and/or [Section 9.8.2](#982-cabrowser-forum-organization-identifier-extension).
 
 * **VAT**:
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1700,7 +1700,7 @@ The following Registration Schemes are currently recognized as valid under these
 
 * **VAT**:
 
-  Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). For the purpose of identifying the country, especially for the "VAT" Registration Scheme, Greece MAY use the prefix "EL".
+  Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). For the purpose of identifying the tax authority of Greece, the country prefix "EL" MAY be used instead of "GR".
 
 * **PSD**:
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1700,7 +1700,7 @@ The following Registration Schemes are currently recognized as valid under these
 
 * **VAT**:
 
-  Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). For the purpose of identifying the tax authority of Greece, the country prefix "EL" MAY be used instead of "GR".
+  Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). For the purpose of identifying tax authorities, the country prefix described in article 215 of EU Council Directive 2006/112/EC, as amended, MAY be used instead of the ISO 3166 2-letter country codes.
 
 * **PSD**:
 


### PR DESCRIPTION
The EV Guidelines have strict rules in the organizationIdentifier values and require the country code of all currently-allowed Registration Schemes (NTR, VAT, PSD) to follow the ISO 3166-1 for the 2-letter country prefix.

The organizationIdentifier language mainly came from ETSI ESI 319 412-1 and then the SCWG made several modifications. However, there is an exception for Greece specifically for the VAT Registration Scheme that is aligned with Article 215 of [Council Directive 2006/112/EC](https://eur-lex.europa.eu/eli/dir/2006/112/oj) that allows Greece to use the country prefix "EL". In practice, Greece uses the prefix "EL" to identify itself next to the VAT number of all Legal Entities registered/incorporated/established in Greece, and all other European Countries use this prefix to identify Greek VAT numbers. You can easily verify this in the [VIES VAT number validation website](https://ec.europa.eu/taxation_customs/vies/#/vat-validation) where Greece is listed as"EL".

This Directive has been amended by [Council Directive 2020/1756](https://data.europa.eu/eli/dir/2020/1756/oj) to also support a different country prefix "XI" for Northern Ireland, so it is preferred to allow the current and future exceptions by pointing to the EU Directive instead of listing each exception in the EV Guidelines.