### PR TITLE
SC-72 - Delete except to policyQualifiers in EVGs; align with BRs by making them NOT RECOMMENDED

### DIFF
--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -608,33 +608,13 @@ All provisions of the Baseline Requirements concerning Minimum Cryptographic Alg
 
    Otherwise, it MAY contain the anyPolicy identifier.
 
-2. The following fields MUST be present if the Subordinate CA is not controlled by the entity that controls the Root CA.
-
-   * `certificatePolicies:policyQualifiers:policyQualifierId`
-
-      `id-qt 1` [RFC 5280]
-
-   * `certificatePolicies:policyQualifiers:qualifier:cPSuri`
-
-      HTTP URL for the Root CA's Certification Practice Statement
-
-3. The `certificatePolicies` extension in EV Certificates issued to Subscribers MUST include the following:
+2. The `certificatePolicies` extension in EV Certificates issued to Subscribers MUST include the following:
 
    * `certificatePolicies:policyIdentifier` (Required)
 
       The Issuer's EV policy identifier
 
-4. Including `policyQualifiers` in the `certificatePolicies` extension in EV Certificates issued to Subscribers is NOT RECOMMENDED, but when included MUST include the following:
-
-   * `certificatePolicies:policyQualifiers:policyQualifierId` (Required)
-
-      `id-qt 1` [RFC 5280]
-
-   * `certificatePolicies:policyQualifiers:qualifier:cPSuri` (Required)
-
-      The HTTP or HTTPS URL for the Issuing CA’s Certificate Policies, Certification Practice Statement, Relying Party Agreement, or other pointer to online policy information provided by the Issuing CA.
-
-5. The `cRLDistributionPoints` extension MUST be present in Subscriber Certificates if the certificate does not specify OCSP responder locations in an `authorityInformationAccess` extension.
+3. The `cRLDistributionPoints` extension MUST be present in Subscriber Certificates if the certificate does not specify OCSP responder locations in an `authorityInformationAccess` extension.
 
 ## 9.8. Certificate Extensions
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -624,15 +624,17 @@ All provisions of the Baseline Requirements concerning Minimum Cryptographic Alg
 
       The Issuer's EV policy identifier
 
+4. Including `policyQualifiers` in the `certificatePolicies` extension in EV Certificates issued to Subscribers is NOT RECOMMENDED, but when included MUST include the following:
+
    * `certificatePolicies:policyQualifiers:policyQualifierId` (Required)
 
       `id-qt 1` [RFC 5280]
 
    * `certificatePolicies:policyQualifiers:qualifier:cPSuri` (Required)
 
-      HTTP URL for the Subordinate CA's Certification Practice Statement
+      The HTTP or HTTPS URL for the Issuing CA’s Certificate Policies, Certification Practice Statement, Relying Party Agreement, or other pointer to online policy information provided by the Issuing CA.
 
-4. The `cRLDistributionPoints` extension MUST be present in Subscriber Certificates if the certificate does not specify OCSP responder locations in an `authorityInformationAccess` extension.
+5. The `cRLDistributionPoints` extension MUST be present in Subscriber Certificates if the certificate does not specify OCSP responder locations in an `authorityInformationAccess` extension.
 
 ## 9.8. Certificate Extensions
 


### PR DESCRIPTION
This ballot updates the TLS Extended Validation Guidelines (EVGs) by removing the exceptions to `policyQualifiers` in section 9.7, to align them with the Baseline Requirements (BRs). 

As result, this ballot changes `policyQualifiers` from `MUST` to `NOT RECOMMENDED` as stated in the TLS Baseline Requirements, resolving a discrepancy introduced by [Ballot SC-62v2](https://cabforum.org/2023/03/17/ballot-sc62v2-certificate-profiles-update/) between section [7.1.2.7.9 Subscriber Certificate Policies](https://cabforum.org/working-groups/server/baseline-requirements/requirements/#71279-subscriber-certificate-certificate-policies) of the BRs and the [Additional Technical Requirements for EV Certificates](https://cabforum.org/working-groups/server/extended-validation/guidelines/#97-additional-technical-requirements-for-ev-certificates) in the EVGs.

The following motion has been proposed by Paul van Brouwershaven (Entrust) and endorsed by Dimitris Zacharopoulos (HARICA) and Iñigo Barreira (Sectigo).