### PR TITLE
SC65: Convert EVGs into RFC 3647 format v2 (#440)

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,9 +1,10 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
-subtitle: Version 2.0.2
+subtitle: Version 2.0.3
 author:
   - CA/Browser Forum
-date: 8-January-2024  
+date: 19-January-2024  
+
 
 
 copyright: |
@@ -767,7 +768,7 @@ Confirming the Applicant's control over the FQDN by confirming the presence of a
 If a Random Value is used, the CA SHALL provide a Random Value unique to the Certificate request and SHALL not use the Random Value after
 
   i. 30 days or
-  ii. if the Applicant submitted the Certificate request, the time frame permitted for reuse of validated information relevant to the Certificate (such as in [Section 4.2.1](#421-performing-identification-and-authentication-functions) of these Guidelines or Section 11.14.3 of the EV Guidelines).
+  ii. if the Applicant submitted the Certificate request, the time frame permitted for reuse of validated information relevant to the Certificate (such as in [Section 4.2.1](#421-performing-identification-and-authentication-functions) of these Guidelines or Section 3.2.2.14.3 of the EV Guidelines).
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
@@ -2377,7 +2378,7 @@ For a Subscriber Certificate to be Extended Validation, it MUST comply with the 
 
 | __Field__             | __Requirements__     |
 | --                    | -------              |
-| `subject`             | See Guidelines for the Issuance and Management of Extended Validation Certificates, Section 9.2. |
+| `subject`             | See Guidelines for the Issuance and Management of Extended Validation Certificates, Section 7.1.4.2. |
 | `certificatePolicies` | MUST be present. MUST assert the [Reserved Certificate Policy Identifier](#7161-reserved-certificate-policy-identifiers) of `2.23.140.1.1` as a `policyIdentifier`. See [Section 7.1.2.7.9](#71279-subscriber-certificate-certificate-policies). |
 | All other extensions  | See [Section 7.1.2.7.6](#71276-subscriber-certificate-extensions) and the Guidelines for the Issuance and Management of Extended Validation Certificates. |
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,10 +1,10 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
-subtitle: Version 2.0.3
+subtitle: Version 2.0.4
 author:
   - CA/Browser Forum
 
-date: 15-April-2024  
+date: 17-April-2024  
 
 
 
@@ -138,7 +138,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.0.1 | SC63  | Make OCSP optional, require CRLs, and incentivize automation | 17-Aug-2023 | 15-Mar-2024 |
 | 2.0.2 | SC66 | 2023 Cleanup | 23-Nov-2023 | 8-Jan-2024 |
 | 2.0.3 | SC69 | Clarify router and firewall logging requirements | 13-March-2024 | 15-April-2024 |
-
+| 2.0.4 | SC65 | Convert EVGs into RFC 3647 format | 15-March-2024 | 15-May-2024 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -4,7 +4,7 @@ title: Guidelines for the Issuance and Management of Extended Validation Certifi
 subtitle: Version 2.0.0
 author:
   - CA/Browser Forum
-date: 8 June, 2023
+date: 17 April, 2024
 copyright: |
   Copyright 2024 CA/Browser Forum
 
@@ -79,6 +79,7 @@ These Guidelines do not address the verification of information, or the issuance
 | 1.7.9 | SC54 | Onion Cleanup | 24-Mar-2022 | 23-Apr-2022 |
 | 1.8.0 | SC56 | 2022 Cleanup | 25-Oct-2022 | 30-Nov-2022 |
 | 1.8.1 | SC68 | Allow VATEL and VATXI for organizationIdentifier | 1-Feb-2024 | 4-Mar-2024 |
+| 2.0.0 | SC65 | Convert EVGs into RFC 3647 format | 15-March-2024 | 15-May-2024 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -24,6 +24,7 @@ The Guidelines for the Issuance and Management of Extended Validation Certificat
 **The CA/Browser Forum**
 
 The CA/Browser Forum is a voluntary open organization of certification authorities and suppliers of Internet browsers and other relying-party software applications.  Membership is listed at <https://cabforum.org/members/>.
+
 ## 1.1  Overview
 These Guidelines for the issuance and management of Extended Validation Certificates describe certain of the minimum requirements that a Certification Authority must meet in order to issue Extended Validation Certificates.   Subject Organization information from Valid EV Certificates may be displayed in a special manner by certain relying-party software applications (e.g., browser software) in order to provide users with a trustworthy confirmation of the identity of the entity that controls the Web site they are accessing. These Guidelines incorporate the Baseline Requirements established by the CA/Browser Forum by reference.  A copy of the Baseline Requirements is available on the CA/Browser Forum's website at <https://www.cabforum.org/>.
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -1,17 +1,18 @@
 ---
 title: Guidelines for the Issuance and Management of Extended Validation Certificates
-subtitle: Version 1.8.1
+
+subtitle: Version 2.0.0
 author:
   - CA/Browser Forum
-date: 4 March, 2024
+date: 8 June, 2023
 copyright: |
   Copyright 2024 CA/Browser Forum
+
 
   This work is licensed under the Creative Commons Attribution 4.0 International license.
 ---
 
-# Introduction
-
+# 1.  INTRODUCTION
 The Guidelines describe an integrated set of technologies, protocols, identity proofing, lifecycle management, and auditing practices specifying the minimum requirements that must be met in order to issue and maintain Extended Validation Certificates ("EV Certificates") concerning an organization.  Subject Organization information from valid EV Certificates can then be used in a special manner by certain relying-party software applications (e.g., browser software) in order to provide users with a trustworthy confirmation of the identity of the entity that controls the Web site or other services they are accessing.  Although initially intended for use in establishing Web-based data communication conduits via TLS/SSL protocols, extensions are envisioned for S/MIME, time-stamping, VoIP, IM, Web services, etc.
 
 The primary purposes of Extended Validation Certificates are to: 1) identify the legal entity that controls a Web or service site, and 2) enable encrypted communications with that site.  The secondary purposes include significantly enhancing cybersecurity by helping establish the legitimacy of an organization claiming to operate a Web site, and providing a vehicle that can be used to assist in addressing problems related to distributing malware, phishing, identity theft, and diverse forms of online fraud.
@@ -23,9 +24,15 @@ The Guidelines for the Issuance and Management of Extended Validation Certificat
 **The CA/Browser Forum**
 
 The CA/Browser Forum is a voluntary open organization of certification authorities and suppliers of Internet browsers and other relying-party software applications.  Membership is listed at <https://cabforum.org/members/>.
+## 1.1  Overview
+These Guidelines for the issuance and management of Extended Validation Certificates describe certain of the minimum requirements that a Certification Authority must meet in order to issue Extended Validation Certificates.   Subject Organization information from Valid EV Certificates may be displayed in a special manner by certain relying-party software applications (e.g., browser software) in order to provide users with a trustworthy confirmation of the identity of the entity that controls the Web site they are accessing. These Guidelines incorporate the Baseline Requirements established by the CA/Browser Forum by reference.  A copy of the Baseline Requirements is available on the CA/Browser Forum's website at <https://www.cabforum.org/>.
 
-## Document History
+These Guidelines address the basic issue of validating Subject identity information in EV Certificates and some related matters.   They do not address all of the related matters, such as certain technical and operational ones. This version of the Guidelines addresses only requirements for EV Certificates intended to be used for SSL/TLS authentication on the Internet and for code signing.  Similar requirements for S/MIME, time-stamping, VoIP, IM, Web services, etc. may be covered in future versions.
 
+These Guidelines do not address the verification of information, or the issuance, use, maintenance, or revocation of EV Certificates by enterprises that operate their own Public Key Infrastructure for internal purposes only, where its Root CA Certificate is not distributed by any Application Software Supplier.
+
+## 1.2  Document name and identification
+### 1.2.1  Revisions
 | **Ver.** | **Ballot** | **Description** | **Adopted** | **Effective\*** |
 |-|-|-----|--|--|
 | 1.4.0 | 72 | Reorganize EV Documents | 29 May 2012 | 29 May 2012 |
@@ -78,28 +85,42 @@ The CA/Browser Forum is a voluntary open organization of certification authoriti
 
 | **Compliance** | **Section(s)** | **Summary Description (See Full Text for Details)** |
 |--|--|----------|
-| 2020-01-31 | [9.2.8](#928-subject-organization-identifier-field) | If subject:organizationIdentifier is present, the CA/Browser Forum Organization Identifier Extension MUST be present |
-| 2020-09-01 | [9.4](#94-maximum-validity-period-for-ev-certificate) & Appendix F | Certificates issued MUST NOT have a Validity Period greater than 398 days. |
-| 2020-10-01 | [11.1.3](#1113-disclosure-of-verification-sources) | Prior to using an Incorporating Agency or Registration Agency, the CA MUST ensure the agency has been publicly disclosed |
-| 2022-09-01 | [9.2.7](#927-subject-organizational-unit-name-field) | CAs MUST NOT include the organizationalUnitName field in the Subject |
+| 2020-01-31 | [9.2.8] | If subject:organizationIdentifier is present, the CA/Browser Forum Organization Identifier Extension MUST be present |
+| 2020-09-01 | [9.4] & Appendix F | Certificates issued MUST NOT have a Validity Period greater than 398 days. |
+| 2020-10-01 | [11.1.3] | Prior to using an Incorporating Agency or Registration Agency, the CA MUST ensure the agency has been publicly disclosed |
+| 2022-09-01 | [9.2.7] | CAs MUST NOT include the organizationalUnitName field in the Subject |
 
 **Implementers' Note**: Version 1.3 of these EV Guidelines was published on 20 November 2010 and supplemented through May 2012 when version 1.4 was published.  ETSI TS 102 042 and ETSI TR 101 564 Technical Report: Guidance on ETSI TS 102 042 for Issuing Extended Validation Certificates for Auditors and CSPs reference version 1.3 of these EV Guidelines, and ETSI Draft EN 319 411-1 references version 1.4.  Version 1.4.5 of Webtrust(r) for Certification Authorities – Extended Validation Audit Criteria references version 1.4.5 of these EV Guidelines.  As illustrated in the Document History table above, the CA/Browser Forum continues to improve relevant industry guidelines, including this document, the Baseline Requirements, and the Network and Certificate System Security Requirements.  We encourage all CAs to conform to each revision on the date specified without awaiting a corresponding update to an applicable audit criterion.  In the event of a conflict between an existing audit criterion and a guideline revision, we will communicate with the audit community and attempt to resolve any uncertainty. We will respond to implementation questions directed to questions@cabforum.org.  Our coordination with compliance auditors will continue as we develop guideline revision cycles that harmonize with the revision cycles for audit criteria, the compliance auditing periods and cycles of CAs, and the CA/Browser Forum's guideline implementation dates.
 
-# 1. Scope
+## 1.3  PKI participants
 
-These Guidelines for the issuance and management of Extended Validation Certificates describe certain of the minimum requirements that a Certification Authority must meet in order to issue Extended Validation Certificates.   Subject Organization information from Valid EV Certificates may be displayed in a special manner by certain relying-party software applications (e.g., browser software) in order to provide users with a trustworthy confirmation of the identity of the entity that controls the Web site they are accessing. These Guidelines incorporate the Baseline Requirements established by the CA/Browser Forum by reference.  A copy of the Baseline Requirements is available on the CA/Browser Forum's website at <https://www.cabforum.org/>.
+### 1.3.1  Certification authorities
 
-These Guidelines address the basic issue of validating Subject identity information in EV Certificates and some related matters.   They do not address all of the related matters, such as certain technical and operational ones. This version of the Guidelines addresses only requirements for EV Certificates intended to be used for SSL/TLS authentication on the Internet and for code signing.  Similar requirements for S/MIME, time-stamping, VoIP, IM, Web services, etc. may be covered in future versions.
+### 1.3.2  Registration authorities
+The CA MAY delegate the performance of all or any part of a requirement of these Guidelines to an Affiliate or a Registration Authority (RA) or subcontractor, provided that the process employed by the CA fulfills all of the requirements of [Section 3.2.2.13](#32213-final-cross-correlation-and-due-diligence).
+Affiliates and/or RAs must comply with the qualification requirements of [Section 5.3.2](#532-background-check-procedures).
 
-These Guidelines do not address the verification of information, or the issuance, use, maintenance, or revocation of EV Certificates by enterprises that operate their own Public Key Infrastructure for internal purposes only, where its Root CA Certificate is not distributed by any Application Software Supplier.
+The CA SHALL verify that the Delegated Third Party's personnel involved in the issuance of a Certificate meet the training and skills requirements of [Section 5.3](#53-personnel-controls) and the document retention and event logging requirements of [Section 5.4](#54-audit-logging-procedures).
 
-# 2. Purpose
+In all cases, the CA MUST contractually obligate each Affiliate, RA, subcontractor, and Enterprise RA to comply with all applicable requirements in these Guidelines and to perform them as required of the CA itself.  The CA SHALL enforce these obligations and internally audit each Affiliate's, RA's, subcontractor's, and Enterprise RA's compliance with these Requirements on an annual basis.
 
-## 2.1. Purpose of EV Certificates
+#### 1.3.2.1  Enterprise Registration authorities
+The CA MAY contractually authorize a Subscriber to perform the RA function and authorize the CA to issue additional EV Certificates.  In such case, the Subscriber SHALL be considered an Enterprise RA, and the following requirements SHALL apply:
 
+1. In all cases, the Subscriber MUST be an organization verified by the CA in accordance with these Guidelines;
+2. The CA MUST impose these limitations as a contractual requirement with the Enterprise RA and monitor compliance by the Enterprise RA; and
+3. The Final Cross-Correlation and Due Diligence requirements of [Section 3.2.2.13](#32213-final-cross-correlation-and-due-diligence) MAY be performed by a single person representing the Enterprise RA.
+
+Enterprise RAs that authorize the issuance of EV Certificates solely for its own organization are exempted from the audit requirements of [Section 8](#8-compliance-audit-and-other-assessments). In all other cases, the requirements of [Section 8](#8-compliance-audit-and-other-assessments) SHALL apply.
+
+### 1.3.3  Subscribers
+### 1.3.4 Relying parties
+### 1.3.5  Other participants
+## 1.4  Certificate usage
+### 1.4.1  Appropriate certificate uses
 EV Certificates are intended for establishing Web-based data communication conduits via the TLS/SSL protocols and for verifying the authenticity of executable code.
 
-### 2.1.1. Primary Purposes
+#### 1.4.1.1 Primary Purposes
 
 The primary purposes of an EV Certificate are to:
 
@@ -107,7 +128,7 @@ The primary purposes of an EV Certificate are to:
 
 2. **Enable encrypted communications with a Web site**: Facilitate the exchange of encryption keys in order to enable the encrypted communication of information over the Internet between the user of an Internet browser and a Web site.
 
-### 2.1.2. Secondary Purposes
+#### 1.4.1.2 Secondary Purposes
 
 The secondary purposes of an EV Certificate are to help establish the legitimacy of a business claiming to operate a Web site or distribute executable code, and to provide a vehicle that can be used to assist in addressing problems related to phishing, malware, and other forms of online identity fraud.  By providing more reliable third-party verified identity and address information regarding the business, EV Certificates may help to:
 
@@ -115,21 +136,23 @@ The secondary purposes of an EV Certificate are to help establish the legitimacy
 2. Assist companies that may be the target of phishing attacks or online identity fraud by providing them with a tool to better identify themselves to users; and
 3. Assist law enforcement organizations in their investigations of phishing and other online identity fraud, including where appropriate, contacting, investigating, or taking legal action against the Subject.
 
-### 2.1.3. Excluded Purposes
-
+### 1.4.2 Prohibited certificate uses
 EV Certificates focus only on the identity of the Subject named in the Certificate, and not on the behavior of the Subject.  As such, an EV Certificate is **not** intended to provide any assurances, or otherwise represent or warrant:
 
 1. That the Subject named in the EV Certificate is actively engaged in doing business;
 2. That the Subject named in the EV Certificate complies with applicable laws;
 3. That the Subject named in the EV Certificate is trustworthy, honest, or reputable in its business dealings; or
 4. That it is "safe" to do business with the Subject named in the EV Certificate.
+   
+## 1.5  Policy administration
+### 1.5.1  Organization administering the document
+### 1.5.2  Contact person
+### 1.5.3  Person determining CPS suitability for the policy
+### 1.5.4  CPS approval procedures
 
-# 3. References
+## 1.6  Definitions and acronyms
 
-See Baseline Requirements, which are available at <https://www.cabforum.org/>.
-
-# 4. Definitions
-
+### 1.6.1  Definitions
 Capitalized Terms are defined in the Baseline Requirements except where provided below:
 
 **Accounting Practitioner**: A certified public accountant, chartered accountant, or a person with an equivalent license within the country of the Applicant's Jurisdiction of Incorporation or Registration or any jurisdiction where the Applicant maintains an office or physical facility; provided that an accounting standards body in the jurisdiction maintains full (not "suspended" or "associate") membership status with the International Federation of Accountants.
@@ -215,9 +238,9 @@ Capitalized Terms are defined in the Baseline Requirements except where provided
 
 **Private Organization**: A non-governmental legal entity (whether ownership interests are privately held or publicly traded) whose existence was created by a filing with (or an act of) the Incorporating Agency or equivalent in its Jurisdiction of Incorporation.
 
-**Qualified Auditor**: An independent public accounting firm that meets the auditing qualification requirements specified in [Section 17.6](#176-auditor-qualification).
+**Qualified Auditor**: An independent public accounting firm that meets the auditing qualification requirements specified in [Section 8.2](#82-identityqualifications-of-assessor).
 
-**Qualified Government Information Source**: A database maintained by a Government Entity (e.g. SEC filings) that meets the requirements of [Section 11.11.6](#11116-qualified-government-information-source).
+**Qualified Government Information Source**: A database maintained by a Government Entity (e.g. SEC filings) that meets the requirements of [Section 3.2.2.11.6](#322116-qualified-government-information-source).
 
 **Qualified Government Tax Information Source**: A Qualified Governmental Information Source that specifically contains tax information relating to Private Organizations, Business Entities, or Individuals.
 
@@ -254,11 +277,11 @@ Capitalized Terms are defined in the Baseline Requirements except where provided
 
 **Translator**: An individual or Business Entity that possesses the requisite knowledge and expertise to accurately translate the words of a document written in one language to the native language of the CA.
 
-**Verified Accountant Letter**: A document meeting the requirements specified in [Section 11.11.2](#11112-verified-accountant-letter).
+**Verified Accountant Letter**: A document meeting the requirements specified in [Section 3.2.2.11.2](#322112-verified-accountant-letter).
 
-**Verified Legal Opinion**: A document meeting the requirements specified in [Section 11.11.1](#11111-verified-legal-opinion).
+**Verified Legal Opinion**: A document meeting the requirements specified in [Section 3.2.2.11.1](#322111-verified-legal-opinion).
 
-**Verified Method of Communication**: The use of a telephone number, a fax number, an email address, or postal delivery address, confirmed by the CA in accordance with [Section 11.5](#115-verified-method-of-communication) as a reliable way of communicating with the Applicant.
+**Verified Method of Communication**: The use of a telephone number, a fax number, an email address, or postal delivery address, confirmed by the CA in accordance with [Section 3.2.2.5](#3225-verified-method-of-communication) as a reliable way of communicating with the Applicant.
 
 **Verified Professional Letter**: A Verified Accountant Letter or Verified Legal Opinion.
 
@@ -268,8 +291,7 @@ Capitalized Terms are defined in the Baseline Requirements except where provided
 
 **WebTrust Seal of Assurance**: An affirmation of compliance resulting from the WebTrust Program for CAs.
 
-# 5. Abbreviations and Acronyms
-
+### 1.6.2  Acronyms
 Abbreviations and Acronyms are defined in the Baseline Requirements except as otherwise defined herein:
 
 | **Acronym** | **Meaning** |
@@ -294,45 +316,17 @@ Abbreviations and Acronyms are defined in the Baseline Requirements except as ot
 | SEC | (US Government) Securities and Exchange Commission |
 | UTC(k) | National realization of Coordinated Universal Time |
 
-# 6. Conventions
+### 1.6.3  References
+See Baseline Requirements, which are available at <https://www.cabforum.org/>.
 
+### 1.6.4  Conventions
 Terms not otherwise defined in these Guidelines shall be as defined in applicable agreements, user manuals, certification practice statements (CPS), and certificate policies (CP) of the CA issuing EV Certificates.
 
 The key words "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in these Guidelines shall be interpreted in accordance with RFC 2119.
 
 By convention, this document omits time and timezones when listing effective requirements such as dates. Except when explicitly specified, the associated time with a date shall be 00:00:00 UTC.
 
-# 7. Certificate Warranties and Representations
-
-## 7.1. EV Certificate Warranties
-
-When the CA issues an EV Certificate, the CA and its Root CA represent and warrant to the Certificate Beneficiaries listed in Section 9.6.1 of the Baseline Requirements, during the period when the EV Certificate is Valid, that the CA has followed the requirements of these Guidelines and its EV Policies in issuing and managing the EV Certificate and in verifying the accuracy of the information contained in the EV Certificate.  The EV Certificate Warranties specifically include, but are not limited to, the following:
-
-A.  **Legal Existence**: The CA has confirmed with the Incorporating or Registration Agency in the Subject's Jurisdiction of Incorporation or Registration that, as of the date the EV Certificate was issued, the Subject named in the EV Certificate legally exists as a valid organization or entity in the Jurisdiction of Incorporation or Registration;
-B.  **Identity**: The CA has confirmed that, as of the date the EV Certificate was issued, the legal name of the Subject named in the EV Certificate matches the name on the official government records of the Incorporating or Registration Agency in the Subject's Jurisdiction of Incorporation or Registration, and if an assumed name is also included, that the assumed name is properly registered by the Subject in the jurisdiction of its Place of Business;
-C.  **Right to Use Domain Name**: The CA has taken all steps reasonably necessary to verify that, as of the date the EV Certificate was issued, the Subject named in the EV Certificate has the right to use all the Domain Name(s) listed in the EV Certificate;
-D.  **Authorization for EV Certificate**: The CA has taken all steps reasonably necessary to verify that the Subject named in the EV Certificate has authorized the issuance of the EV Certificate;
-E.  **Accuracy of Information**: The CA has taken all steps reasonably necessary to verify that all of the other information in the EV Certificate is accurate, as of the date the EV Certificate was issued;
-F.  **Subscriber Agreement**: The Subject named in the EV Certificate has entered into a legally valid and enforceable Subscriber Agreement with the CA that satisfies the requirements of these Guidelines or, if they are affiliated, the Applicant Representative has acknowledged and accepted the Terms of Use;
-G.  **Status**: The CA will follow the requirements of these Guidelines and maintain a 24 x 7 online-accessible Repository with current information regarding the status of the EV Certificate as Valid or revoked; and
-H.  **Revocation**: The CA will follow the requirements of these Guidelines and revoke the EV Certificate for any of the revocation reasons specified in these Guidelines.
-
-## 7.2. By the Applicant
-
-EV Certificate Applicants make the commitments and warranties set forth in Section 9.6.3 of the Baseline Requirements for the benefit of the CA and Certificate Beneficiaries.
-
-# 8. Community and Applicability
-
-## 8.1. Issuance of EV Certificates
-
-The CA MAY issue EV Certificates, provided that the CA and its Root CA satisfy the requirements in these Guidelines and the Baseline Requirements.
-
-If a court or government body with jurisdiction over the activities covered by these Guidelines determines that the performance of any mandatory requirement is illegal, then such requirement is considered reformed to the minimum extent necessary to make the requirement valid and legal.  This applies only to operations or certificate issuances that are subject to the laws of that jurisdiction.  The parties involved SHALL notify the CA / Browser Forum of the facts, circumstances, and law(s) involved, so that the CA/Browser Forum may revise these Guidelines accordingly.
-
-## 8.2. EV Policies
-
-### 8.2.1. Implementation
-
+# 2. PUBLICATION AND REPOSITORY RESPONSIBILITIES
 Each CA must develop, implement, enforce, display prominently on its Web site, and periodically update as necessary its own auditable EV Certificate practices, policies and procedures, such as a Certification Practice Statement (CPS) and Certificate Policy (CP) that:
 
 A.  Implement the requirements of these Guidelines as they are revised from time-to-time;
@@ -344,13 +338,11 @@ B.  Implement the requirements of
 
 C.  Specify the CA's and its Root CA's entire root certificate hierarchy including all roots that its EV Certificates depend on for proof of those EV Certificates' authenticity.
 
-### 8.2.2. Disclosure
-
-Each CA MUST publicly disclose its Certificate Policy and/or Certification Practice Statement through an appropriate and readily accessible online means that is available on a 24x7 basis. The CA SHALL publicly disclose its CA business practices to the extent required by the CA's selected audit scheme (see [Section 17.1](#171-eligible-audit-schemes)).
+## 2.1  Repositories
+## 2.2  Publication of certification information
+Each CA MUST publicly disclose its Certificate Policy and/or Certification Practice Statement through an appropriate and readily accessible online means that is available on a 24x7 basis. The CA SHALL publicly disclose its CA business practices to the extent required by the CA's selected audit scheme (see [Section 8](#8-compliance-audit-and-other-assessments)).
 
 The CA's Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with RFC 3647. The Certificate Policy and/or Certification Practice Statement MUST include all material required by RFC 3647.
-
-## 8.3. Commitment to Comply with Recommendations
 
 Each CA SHALL publicly give effect to these Guidelines and represent that they will adhere to the latest published version by incorporating them into their respective EV Policies, using a clause such as the following (which must include a link to the official version of these Guidelines):
 
@@ -358,374 +350,34 @@ Each CA SHALL publicly give effect to these Guidelines and represent that they w
 
 In addition, the CA MUST include (directly or by reference) the applicable requirements of these Guidelines in all contracts with Subordinate CAs, RAs, Enterprise RAs, and subcontractors that involve or relate to the issuance or maintenance of EV Certificates.  The CA MUST enforce compliance with such terms.
 
-## 8.4. Insurance
-
-Each CA SHALL maintain the following insurance related to their respective performance and obligations under these Guidelines:
-
-A.  Commercial General Liability insurance (occurrence form) with policy limits of at least two million US dollars in coverage; and
-
-B.  Professional Liability/Errors and Omissions insurance, with policy limits of at least five million US dollars in coverage, and including coverage for:
-    i. claims for damages arising out of an act, error, or omission, unintentional breach of contract, or neglect in issuing or maintaining EV Certificates, and;
-    ii. claims for damages arising out of infringement of the proprietary rights of any third party (excluding copyright, and trademark infringement), and invasion of privacy and advertising injury.
-
-Such insurance must be with a company rated no less than A- as to Policy Holder's Rating in the current edition of Best's Insurance Guide (or with an association of companies each of the members of which are so rated).
-
-A CA MAY self-insure for liabilities that arise from such party's performance and obligations under these Guidelines provided that it has at least five hundred million US dollars in liquid assets based on audited financial statements in the past twelve months, and a quick ratio (ratio of liquid assets to current liabilities) of not less than 1.0.
-
-## 8.5. Obtaining EV Certificates
-
-### 8.5.1. General
-
-The CA MAY only issue EV Certificates to Applicants that meet the Private Organization, Government Entity, Business Entity and Non-Commercial Entity requirements specified below.
-
-### 8.5.2. Private Organization Subjects
-
-An Applicant qualifies as a Private Organization if:
-
-1. The entity's legal existence is created or recognized by a by a filing with (or an act of) the Incorporating or Registration Agency in its Jurisdiction of Incorporation or Registration (e.g., by issuance of a certificate of incorporation, registration number, etc.) or created or recognized by a Government Agency (e.g. under a charter, treaty, convention, or equivalent recognition instrument);
-
-2. The entity designated with the Incorporating or Registration Agency a Registered Agent, a Registered Office (as required under the laws of the Jurisdiction of Incorporation or Registration), or an equivalent facility;
-
-3. The entity is not designated on the records of the Incorporating or Registration Agency by labels such as "inactive," "invalid," "not current," or the equivalent;
-
-4. The entity has a verifiable physical existence and business presence;
-
-5. The entity's Jurisdiction of Incorporation, Registration, Charter, or License, and/or its Place of Business is not in any country where the CA is prohibited from doing business or issuing a certificate by the laws of the CA's jurisdiction; and
-
-6. The entity is not listed on any government denial list or prohibited list (e.g., trade embargo) under the laws of the CA's jurisdiction.
-
-### 8.5.3. Government Entity Subjects
-
-An Applicant qualifies as a Government Entity if:
-
-1. The entity's legal existence was established by the political subdivision in which the entity operates;
-
-2. The entity is not in any country where the CA is prohibited from doing business or issuing a certificate by the laws of the CA's jurisdiction; and
-
-3. The entity is not listed on any government denial list or prohibited list (e.g., trade embargo) under the laws of the CA's jurisdiction.
-
-### 8.5.4. Business Entity Subjects
-
-An Applicant qualifies as a Business Entity if:
-
-1. The entity is a legally recognized entity that filed certain forms with a Registration Agency in its jurisdiction, the Registration Agency issued or approved the entity's charter, certificate, or license, and the entity's existence can be verified with that Registration Agency;
-
-2. The entity has a verifiable physical existence and business presence;
-
-3. At least one Principal Individual associated with the entity is identified and validated by the CA;
-
-4. The identified Principal Individual attests to the representations made in the Subscriber Agreement;
-
-5. The CA verifies the entity's use of any assumed name used to represent the entity pursuant to the requirements of [Section 11.3](#113-verification-of-applicants-legal-existence-and-identity--assumed-name);
-
-6. The entity and the identified Principal Individual associated with the entity are not located or residing in any country where the CA is prohibited from doing business or issuing a certificate by the laws of the CA's jurisdiction; and
-
-7. The entity and the identified Principal Individual associated with the entity are not listed on any government denial list or prohibited list (e.g., trade embargo) under the laws of the CA's jurisdiction.
-
-### 8.5.5. Non-Commercial Entity Subjects
-
-An Applicant qualifies as a Non-Commercial Entity if:
-
-1. The Applicant is an International Organization Entity, created under a charter, treaty, convention or equivalent instrument that was signed by, or on behalf of, more than one country's government.  The CA/Browser Forum may publish a listing of Applicants who qualify as an International Organization for EV eligibility; and
-
-2. The Applicant is not headquartered in any country where the CA is prohibited from doing business or issuing a certificate by the laws of the CA's jurisdiction; and
-
-3. The Applicant is not listed on any government denial list or prohibited list (e.g., trade embargo) under the laws of the CA's jurisdiction.
-
-Subsidiary organizations or agencies of an entity that qualifies as a Non-Commercial Entity also qualifies for EV Certificates as a Non-Commercial Entity.
-
-# 9. EV Certificate Content and Profile
-
-This section sets forth minimum requirements for the content of the EV Certificate as they relate to the identity of the CA and the Subject of the EV Certificate.
-
-## 9.1. Issuer Information
-
-Issuer Information listed in an EV Certificate MUST comply with Section 7.1.4.1 of the Baseline Requirements.
-
-## 9.2. Subject Distinguished Name Fields
-
-Subject to the requirements of these Guidelines, the EV Certificate and certificates issued to Subordinate CAs that are not controlled by the same entity as the CA MUST include the following information about the Subject organization in the fields listed:
-
-### 9.2.1. Subject Organization Name Field
-
-__Certificate Field__: `subject:organizationName` (OID 2.5.4.10)  
-__Required/Optional__: Required  
-__Contents__: This field MUST contain the Subject's full legal organization name as listed in the official records of the Incorporating or Registration Agency in the Subject's Jurisdiction of Incorporation or Registration or as otherwise verified by the CA as provided herein. A CA MAY abbreviate the organization prefixes or suffixes in the organization name, e.g., if the official record shows "Company Name Incorporated" the CA MAY include "Company Name, Inc."
-
-When abbreviating a Subject's full legal name as allowed by this subsection, the CA MUST use abbreviations that are not misleading in the Jurisdiction of Incorporation or Registration.
-
-In addition, an assumed name or DBA name used by the Subject MAY be included at the beginning of this field, provided that it is followed by the full legal organization name in parenthesis.
-
-If the combination of names or the organization name by itself exceeds 64 characters, the CA MAY abbreviate parts of the organization name, and/or omit non-material words in the organization name in such a way that the text in this field does not exceed the 64-character limit; provided that the CA checks this field in accordance with [Section 11.12.1](#11121-high-risk-status) and a Relying Party will not be misled into thinking that they are dealing with a different organization. In cases where this is not possible, the CA MUST NOT issue the EV Certificate.
-
-### 9.2.2. Subject Common Name Field
-
-__Certificate Field__: `subject:commonName` (OID: 2.5.4.3)  
-__Required/Optional__: Deprecated (Discouraged, but not prohibited)  
-__Contents__: If present, this field MUST contain a single Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service). This field MUST NOT contain a Wildcard Domain Name unless the FQDN portion of the Wildcard Domain Name is an Onion Domain Name verified in accordance with Appendix B of the Baseline Requirements.
-
-### 9.2.3. Subject Business Category Field
-
-__Certificate Field__: `subject:businessCategory` (OID: 2.5.4.15)  
-__Required/Optional__: Required  
-__Contents__: This field MUST contain one of the following strings: "Private Organization", "Government Entity", "Business Entity", or "Non-Commercial Entity" depending upon whether the Subject qualifies under the terms of [Section 8.5.2](#852-private-organization-subjects), [Section 8.5.3](#853-government-entity-subjects), [Section 8.5.4](#854-business-entity-subjects) or [Section 8.5.5](#855-non-commercial-entity-subjects), respectively.
-
-### 9.2.4. Subject Jurisdiction of Incorporation or Registration Field
-
-__Certificate Fields__:
-
-Locality (if required):  
-  `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1)
-
-State or province (if required):  
-  `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2)
-
-Country:  
-  `subject:jurisdictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3)
-
-__Required/Optional__: Required  
-__Contents__: These fields MUST NOT contain information that is not relevant to the level of the Incorporating Agency or Registration Agency.  For example, the Jurisdiction of Incorporation for an Incorporating Agency or Jurisdiction of Registration for a Registration Agency that operates at the country level MUST include the country information but MUST NOT include the state or province or locality information.  Similarly, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the state or province level MUST include both country and state or province information, but MUST NOT include locality information.  And, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the locality level MUST include the country and state or province information, where the state or province regulates the registration of the entities at the locality level, as well as the locality information.  Country information MUST be specified using the applicable ISO country code.  State or province or locality information (where applicable) for the Subject's Jurisdiction of Incorporation or Registration MUST be specified using the full name of the applicable jurisdiction.
-
-Effective as of 1 October 2020, the CA SHALL ensure that, at time of issuance, the values within these fields have been disclosed within the latest publicly-available disclosure, as described in [Section 11.1.3](#1113-disclosure-of-verification-sources), as acceptable values for the applicable Incorporating Agency or Registration Agency.
-
-### 9.2.5. Subject Registration Number Field
-
-__Certificate Field__: `subject:serialNumber` (OID: 2.5.4.5)  
-__Required/Optional__: __Required__  
-__Contents__: For Private Organizations, this field MUST contain the Registration (or similar) Number assigned to the Subject by the Incorporating or Registration Agency in its Jurisdiction of Incorporation or Registration, as appropriate.  If the Jurisdiction of Incorporation or Registration does not provide a Registration Number, then the date of Incorporation or Registration SHALL be entered into this field in any one of the common date formats.
-
-For Government Entities that do not have a Registration Number or readily verifiable date of creation, the CA SHALL enter appropriate language to indicate that the Subject is a Government Entity.
-
-For Business Entities, the Registration Number that was received by the Business Entity upon government registration SHALL be entered in this field.  For those Business Entities that register with an Incorporating Agency or Registration Agency in a jurisdiction that does not issue numbers pursuant to government registration, the date of the registration SHALL be entered into this field in any one of the common date formats.
-
-Effective as of 1 October 2020, if the CA has disclosed a set of acceptable format or formats for Registration Numbers for the applicable Registration Agency or Incorporating Agency, as described in [Section 11.1.3](#1113-disclosure-of-verification-sources), the CA MUST ensure, prior to issuance, that the Registration Number is valid according to at least one currently disclosed format for that applicable Registration Agency or Incorporating agency.
-
-### 9.2.6. Subject Physical Address of Place of Business Field
-
-__Certificate Fields__:  
-    Number and street: `subject:streetAddress` (OID: 2.5.4.9)  
-    City or town: `subject:localityName` (OID: 2.5.4.7)  
-    State or province (where applicable): `subject:stateOrProvinceName` (OID: 2.5.4.8)  
-    Country: `subject:countryName` (OID: 2.5.4.6)  
-    Postal code: `subject:postalCode` (OID: 2.5.4.17)  
-__Required/Optional__: As stated in Section 7.1.4.2.2 d, e, f, g and h of the Baseline Requirements.  
-__Contents__: This field MUST contain the address of the physical location of the Subject's Place of Business.
-
-### 9.2.7. Subject Organizational Unit Name Field
-
-__Certificate Field__: `subject:organizationalUnitName` (OID: 2.5.4.11)  
-__Required/Optional/Prohibited:__ __Prohibited__. 
-
-### 9.2.8. Subject Organization Identifier Field
-
-__Certificate Field__: `subject:organizationIdentifier` (OID: 2.5.4.97)  
-__Required/Optional__: Optional  
-__Contents__: If present, this field MUST contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme.
-
-The organizationIdentifier MUST be encoded as a PrintableString or UTF8String.
-
-The Registration Scheme MUST be identified using the using the following structure in the presented order:
-
-* 3 character Registration Scheme identifier;
-* 2 character ISO 3166 country code for the nation in which the Registration Scheme is operated, or if the scheme is operated globally ISO 3166 code "XG" shall be used;
-* For the NTR Registration Scheme identifier, if required under [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field), a 2 character ISO 3166-2 identifier for the subdivision (state or province) of the nation in which the Registration Scheme is operated, preceded by plus "+" (0x2B (ASCII), U+002B (UTF-8));
-* a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8));
-* Registration Reference allocated in accordance with the identified Registration Scheme
-
-Note: Registration References MAY contain hyphens, but Registration Schemes, ISO 3166 country codes, and ISO 3166-2 identifiers do not. Therefore if more than one hyphen appears in the structure, the leftmost hyphen is a separator, and the remaining hyphens are part of the Registration Reference.
-
-As in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field), the specified location information MUST match the scope of the registration being referenced.
-
-Examples:
-
-* `NTRGB-12345678` (NTR scheme, Great Britain, Unique Identifier at Country level is 12345678)
-* `NTRUS+CA-12345678` (NTR Scheme, United States - California, Unique identifier at State level is 12345678)
-* `VATDE-123456789` (VAT Scheme, Germany, Unique Identifier at Country Level is 12345678)
-* `PSDBE-NBB-1234.567.890` (PSD Scheme, Belgium, NCA's identifier is NBB, Subject Unique Identifier assigned by the NCA is 1234.567.890)
-
-Registration Schemes listed in [Appendix H](#appendix-h--registration-schemes) are currently recognized as valid under these guidelines.
-
-The CA SHALL:
-
-1. confirm that the organization represented by the Registration Reference is the same as the organization named in the `organizationName` field as specified in [Section 9.2.1](#921-subject-organization-name-field) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field);
-2. further verify the Registration Reference matches other information verified in accordance with [Section 11](#11-verification-requirements);
-3. take appropriate measures to disambiguate between different organizations as described in [Appendix H](#appendix-h--registration-schemes) for each Registration Scheme;
-4. Apply the validation rules relevant to the Registration Scheme as specified in [Appendix H](#appendix-h--registration-schemes).
-
-### 9.2.9. Other Subject Attributes
-
-CAs SHALL NOT include any Subject Distinguished Name attributes except as specified in [Section 9.2](#92-subject-distinguished-name-fields).
-
-## 9.3. Certificate Policy Identification
-
-### 9.3.1. EV Certificate Policy Identification Requirements
-
-This section sets forth minimum requirements for the contents of EV Certificates as they relate to the identification of EV Certificate Policy.
-
-### 9.3.2. EV Subscriber Certificates
-
-Each EV Certificate issued by the CA to a Subscriber MUST contain a policy identifier that is either defined by these Guidelines or the CA in the certificate's `certificatePolicies` extension that:
-
-1. indicates which CA policy statement relates to that Certificate,
-2. asserts the CA's adherence to and compliance with these Guidelines, and
-3. is either the CA/Browser Forum’s EV policy identifier or a policy identifier that, by pre-agreement with the Application Software Supplier, marks the Certificate as being an EV Certificate.
-
-The following Certificate Policy identifier is the CA/Browser Forum’s EV policy identifier:
-`{joint‐iso‐itu‐t(2) international‐organizations(23) ca‐browser‐forum(140) certificate‐policies(1) ev-guidelines (1) } (2.23.140.1.1)`, if the Certificate complies with these Guidelines.
-
-### 9.3.3. Root CA Certificates
-
-The Application Software Supplier identifies Root CAs that are approved to issue EV Certificates by storing EV policy identifiers in metadata associated with Root CA Certificates.
-
-### 9.3.4. EV Subordinate CA Certificates
-
-1. Certificates issued to Subordinate CAs that are not controlled by the issuing CA MUST contain one or more policy identifiers defined by the issuing CA that explicitly identify the EV Policies that are implemented by the Subordinate CA.
-2. Certificates issued to Subordinate CAs that are controlled by the Root CA MAY contain the special `anyPolicy` identifier (OID: 2.5.29.32.0).
-
-### 9.3.5. Subscriber Certificates
-
-A Certificate issued to a Subscriber MUST contain one or more policy identifier(s), defined by the Issuing CA, in the Certificate's `certificatePolicies` extension that indicates adherence to and compliance with these Guidelines.  Each CA SHALL document in its Certificate Policy or Certification Practice Statement that the Certificates it issues containing the specified policy identifier(s) are managed in accordance with these Guidelines.
-
-## 9.4. Maximum Validity Period For EV Certificate
-
-The Validity Period for an EV Certificate SHALL NOT exceed 398 days.
-
-It is RECOMMENDED that EV Subscriber Certificates have a Maximum Validity Period of twelve months.
-
-## 9.5. Subscriber Public Key
-
-The requirements in Section 6.1.1.3 of the Baseline Requirements apply equally to EV Certificates.
-
-## 9.6. Certificate Serial Number
-
-The requirements in Section 7.1 of the Baseline Requirements apply equally to EV Certificates.
-
-## 9.7. Additional Technical Requirements for EV Certificates
-
-All provisions of the Baseline Requirements concerning Minimum Cryptographic Algorithms, Key Sizes, and Certificate Extensions apply to EV Certificates with the following exceptions:
-
-1. If a Subordinate CA Certificates is issued to a Subordinate CA not controlled by the entity that controls the Root CA, the policy identifiers in the `certificatePolicies` extension MUST include the CA's Extended Validation policy identifier.
-
-   Otherwise, it MAY contain the anyPolicy identifier.
-
-2. The following fields MUST be present if the Subordinate CA is not controlled by the entity that controls the Root CA.
-
-   * `certificatePolicies:policyQualifiers:policyQualifierId`
-
-      `id-qt 1` [RFC 5280]
-
-   * `certificatePolicies:policyQualifiers:qualifier:cPSuri`
-
-      HTTP URL for the Root CA's Certification Practice Statement
-
-3. The `certificatePolicies` extension in EV Certificates issued to Subscribers MUST include the following:
-
-   * `certificatePolicies:policyIdentifier` (Required)
-
-      The Issuer's EV policy identifier
-
-   * `certificatePolicies:policyQualifiers:policyQualifierId` (Required)
-
-      `id-qt 1` [RFC 5280]
-
-   * `certificatePolicies:policyQualifiers:qualifier:cPSuri` (Required)
-
-      HTTP URL for the Subordinate CA's Certification Practice Statement
-
-4. The `cRLDistributionPoints` extension MUST be present in Subscriber Certificates if the certificate does not specify OCSP responder locations in an `authorityInformationAccess` extension.
-
-## 9.8. Certificate Extensions
-
-The extensions listed in [Section 9.8](#98-certificate-extensions) are recommended for maximum interoperability between certificates and browsers / applications, but are not mandatory on the CAs except where indicated as “Required”.  CAs may use other extensions that are not listed in [Section 9.8](#98-certificate-extensions), but are encouraged to add them to this section by ballot from time to time to help increase extension standardization across the industry.
-
-If a CA includes an extension in a certificate that has a Certificate field which is named in [Section 9.8](#98-certificate-extensions), the CA must follow the format specified in that subsection.  However, no extension or extension format shall be mandatory on a CA unless specifically stated as “Required” in the subsection that describes the extension.
-
-### 9.8.1. Subject Alternative Name Extension
-
-__Certificate Field__: `subjectAltName:dNSName`  
-__Required/Optional__: __Required__  
-__Contents__: This extension MUST contain one or more host Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service). This extension MUST NOT contain a Wildcard Domain Name unless the FQDN portion of the Wildcard Domain Name is an Onion Domain Name verified in accordance with Appendix B of the Baseline Requirements.
-
-### 9.8.2. CA/Browser Forum Organization Identifier Extension
-
-__Extension Name__: `cabfOrganizationIdentifier` (OID: 2.23.140.3.1)  
-__Verbose OID__: `{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-extensions(3) cabf-organization-identifier(1) }`  
-__Required/Optional__: __Optional (but see below)__  
-__Contents__: If the subject:organizationIdentifier is present, this field MUST be present.
-
-If present, this extension MUST contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme.
-
-The Registration Scheme MUST be encoded as described by the following ASN.1 grammar:
-
-```ASN.1
-id-CABFOrganizationIdentifier OBJECT IDENTIFIER ::= {
-    joint-iso-itu-t(2) international-organizations(23)
-    ca-browser-forum(140) certificate-extensions(3)
-    cabf-organizationIdentifier(1) 
-}
-
-ext-CABFOrganizationIdentifier EXTENSION ::= {
-    SYNTAX CABFOrganizationIdentifier
-    IDENTIFIED BY id-CABFOrganizationIdentifier
-}
-
-CABFOrganizationIdentifier ::= SEQUENCE {
-    registrationSchemeIdentifier PrintableString (SIZE(3)),
-    registrationCountry          PrintableString (SIZE(2)),
-    registrationStateOrProvince  [0] IMPLICIT PrintableString
-                                  (SIZE(0..128)) OPTIONAL,
-    registrationReference        UTF8String
-}
-```
-
-where the subfields have the same values, meanings, and restrictions described in [Section 9.2.8](#928-subject-organization-identifier-field). The CA SHALL validate the contents using the requirements in [Section 9.2.8](#928-subject-organization-identifier-field).
-
-# 10. EV Certificate Request Requirements
-
-## 10.1. General Requirements
-
-### 10.1.1. Documentation Requirements
-
-The documentation requirements in Section 4.1.2 of the Baseline Requirements apply equally to EV Certificates.
-
-### 10.1.2. Role Requirements
-
-The following Applicant roles are required for the issuance of an EV Certificate.
-
-1. **Certificate Requester**: The EV Certificate Request MUST be submitted by an authorized Certificate Requester.  A Certificate Requester is a natural person who is either the Applicant, employed by the Applicant, an authorized agent who has express authority to represent the Applicant, or a third party (such as an ISP or hosting company) that completes and submits an EV Certificate Request on behalf of the Applicant.
-
-2. **Certificate Approver**: The EV Certificate Request MUST be approved by an authorized Certificate Approver.  A Certificate Approver is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant to
-
-   i. act as a Certificate Requester and to authorize other employees or third parties to act as a Certificate Requester, and
-   ii. to approve EV Certificate Requests submitted by other Certificate Requesters.
-
-3. **Contract Signer**: A Subscriber Agreement applicable to the requested EV Certificate MUST be signed by an authorized Contract Signer.  A Contract Signer is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant, and who has authority on behalf of the Applicant to sign Subscriber Agreements.
-
-4. **Applicant Representative**: In the case where the CA and the Subscriber are affiliated, Terms of Use applicable to the requested EV Certificate MUST be acknowledged and agreed to by an authorized Applicant Representative.  An Applicant Representative is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant, and who has authority on behalf of the Applicant to acknowledge and agree to the Terms of Use.
-
-The Applicant MAY authorize one individual to occupy two or more of these roles. The Applicant MAY authorize more than one individual to occupy any of these roles.
-
-## 10.2. EV Certificate Request Requirements
-
-The Certificate Request requirements in Section 4.1.2 of the Baseline Requirements apply equally to EV Certificates subject to the additional more stringent ageing and updating requirement of [Section 11.14](#1114-requirements-for-re-use-of-existing-documentation).
-
-## 10.3. Requirements for Subscriber Agreement and Terms of Use
-
-Section 9.6.3 of the Baseline Requirements applies equally to EV Certificates.  In cases where the Certificate Request does not contain all necessary information about the Applicant, the CA MUST additionally confirm the data with the Certificate Approver or Contract Signer rather than the Certificate Requester.
-
-# 11. Verification Requirements
-
-## 11.1. General Overview
+## 2.3  Time or frequency of publication
+## 2.4  Access controls on repositories
+# 3. IDENTIFICATION AND AUTHENTICATION
+## 3.1  Naming
+### 3.1.1  Types of names
+### 3.1.2  Need for names to be meaningful
+### 3.1.3  Anonymity or pseudonymity of subscribers
+### 3.1.4  Rules for interpreting various name forms
+### 3.1.5  Uniqueness of names
+### 3.1.6  Recognition, authentication, and role of trademarks
+
+## 3.2  Initial identity validation
+
+### 3.2.1 Method to prove possession of private key
+
+### 3.2.2 Authentication of organization identity
+
+#### 3.2.2.1 Overview
 
 This part of the Guidelines sets forth Verification Requirements and Acceptable Methods of Verification for each such Requirement.
 
-### 11.1.1. Verification Requirements – Overview
+##### 3.2.2.1.1 Verification Requirements – Overview
 
 Before issuing an EV Certificate, the CA MUST ensure that all Subject organization information to be included in the EV Certificate conforms to the requirements of, and is verified in accordance with, these Guidelines and matches the information confirmed and documented by the CA pursuant to its verification processes.  Such verification processes are intended to accomplish the following:
 
 1. Verify Applicant's existence and identity, including;
 
-   A.  Verify the Applicant's legal existence and identity (as more fully set forth in [Section 11.2](#112-verification-of-applicants-legal-existence-and-identity)),
+   A.  Verify the Applicant's legal existence and identity (as more fully set forth in [Section 3.2.2.2](#3222-verification-of-applicants-legal-existence-and-identity)),
 
    B.  Verify the Applicant's physical existence (business presence at a physical address), and
 
@@ -743,11 +395,11 @@ Before issuing an EV Certificate, the CA MUST ensure that all Subject organizati
 
    C.  Verify that a Certificate Approver has signed or otherwise approved the EV Certificate Request.
 
-### 11.1.2. Acceptable Methods of Verification – Overview
+##### 3.2.2.1.2 Acceptable Methods of Verification – Overview
 
-As a general rule, the CA is responsible for taking all verification steps reasonably necessary to satisfy each of the Verification Requirements set forth in the subsections below.  The Acceptable Methods of Verification set forth in each of Sections 11.2 through 11.14 (which usually include alternatives) are considered to be the minimum acceptable level of verification required of the CA.  In all cases, however, the CA is responsible for taking any additional verification steps that may be reasonably necessary under the circumstances to satisfy the applicable Verification Requirement.
+As a general rule, the CA is responsible for taking all verification steps reasonably necessary to satisfy each of the Verification Requirements set forth in the subsections below.  The Acceptable Methods of Verification set forth in each of Sections 3.2.2 through 3.2.14 (which usually include alternatives) are considered to be the minimum acceptable level of verification required of the CA.  In all cases, however, the CA is responsible for taking any additional verification steps that may be reasonably necessary under the circumstances to satisfy the applicable Verification Requirement.
 
-### 11.1.3. Disclosure of Verification Sources
+##### 3.2.2.1.3 Disclosure of Verification Sources
 
 Effective as of 1 October 2020, prior to the use of an Incorporating Agency or Registration Agency to fulfill these verification requirements, the CA MUST publicly disclose Agency Information about the Incorporating Agency or Registration Agency. This disclosure SHALL be through an appropriate and readily accessible online means.
 
@@ -760,9 +412,9 @@ This Agency Information SHALL include at least the following:
 
 The CA MUST document where to obtain this information within Section 3.2 of the CA's Certificate Policy and/or Certification Practice Statement.
 
-## 11.2. Verification of Applicant's Legal Existence and Identity
+#### 3.2.2.2 Verification of Applicant's Legal Existence and Identity
 
-### 11.2.1. Verification Requirements
+##### 3.2.2.2.1 Verification Requirements
 
 To verify the Applicant's legal existence and identity, the CA MUST do the following.
 
@@ -792,20 +444,20 @@ To verify the Applicant's legal existence and identity, the CA MUST do the follo
    B.  **Entity Name**: Verify that the Applicant's formal legal name matches the Applicant's name in the EV Certificate Request.
    C.  **Registration Number**: The CA MUST attempt to obtain the Applicant's date of formation, or the identifier for the legislative act that created the International Organization Entity.  In circumstances where this information is not available, the CA MUST enter appropriate language to indicate that the Subject is an International Organization Entity.
 
-### 11.2.2. Acceptable Method of Verification
+##### 3.2.2.2.2 Acceptable Method of Verification
 
-1. **Private Organization Subjects**: Unless verified under subsection (6), all items listed in [Section 11.2.1](#1121-verification-requirements) (1) MUST be verified directly with, or obtained directly from, the Incorporating or Registration Agency in the Applicant's Jurisdiction of Incorporation or Registration. Such verification MAY be through use of a Qualified Government Information Source operated by, or on behalf of, the Incorporating or Registration Agency, or by direct contact with the Incorporating or Registration Agency in person or via mail, e-mail, Web address, or telephone, using an address or phone number obtained directly from the Qualified Government Information Source, Incorporating or Registration Agency, or from a Qualified Independent Information Source.
+1. **Private Organization Subjects**: Unless verified under subsection (6), all items listed in [Section 3.2.2.2.1](#32221-verification-requirements) (1) MUST be verified directly with, or obtained directly from, the Incorporating or Registration Agency in the Applicant's Jurisdiction of Incorporation or Registration. Such verification MAY be through use of a Qualified Government Information Source operated by, or on behalf of, the Incorporating or Registration Agency, or by direct contact with the Incorporating or Registration Agency in person or via mail, e-mail, Web address, or telephone, using an address or phone number obtained directly from the Qualified Government Information Source, Incorporating or Registration Agency, or from a Qualified Independent Information Source.
 
-2. **Government Entity Subjects**: Unless verified under subsection (6), all items listed in [Section 11.2.1](#1121-verification-requirements) (2) MUST either be verified directly with, or obtained directly from, one of the following:
+2. **Government Entity Subjects**: Unless verified under subsection (6), all items listed in [Section 3.2.2.2.1](#32221-verification-requirements) (2) MUST either be verified directly with, or obtained directly from, one of the following:
    i. a Qualified Government Information Source in the political subdivision in which such Government Entity operates;
    ii. a superior governing Government Entity in the same political subdivision as the Applicant (e.g. a Secretary of State may verify the legal existence of a specific State Department), or
    iii. from a judge that is an active member of the federal, state or local judiciary within that political subdivision.
 
-   Any communication from a judge SHALL be verified in the same manner as is used for verifying factual assertions that are asserted by an Attorney as set forth in [Section 11.11.1](#11111-verified-legal-opinion).
+   Any communication from a judge SHALL be verified in the same manner as is used for verifying factual assertions that are asserted by an Attorney as set forth in [Section 3.2.2.11.1](#322111-verified-legal-opinion).
 
    Such verification MAY be by direct contact with the appropriate Government Entity in person or via mail, e-mail, Web address, or telephone, using an address or phone number obtained from a Qualified Independent Information Source.
 
-3. **Business Entity Subjects**: Unless verified under subsection (6), Items listed in [Section 11.2.1](#1121-verification-requirements) (3) (A) through (C) above, MUST be verified directly with, or obtained directly from, the Registration Agency in the Applicant's Jurisdiction of Registration. Such verification MAY be performed by means of a Qualified Government Information Source, a Qualified Governmental Tax Information Source, or by direct contact with the Registration Agency in person or via mail, e-mail, Web address, or telephone, using an address or phone number obtained directly from the Qualified Government Information Source, Qualified Governmental Tax Information Source or Registration Agency, or from a Qualified Independent Information Source. In addition, the CA MUST validate a Principal Individual associated with the Business Entity pursuant to the requirements in subsection (4), below.
+3. **Business Entity Subjects**: Unless verified under subsection (6), Items listed in [Section 3.2.2.2.1](#32221-verification-requirements) (3) (A) through (C) above, MUST be verified directly with, or obtained directly from, the Registration Agency in the Applicant's Jurisdiction of Registration. Such verification MAY be performed by means of a Qualified Government Information Source, a Qualified Governmental Tax Information Source, or by direct contact with the Registration Agency in person or via mail, e-mail, Web address, or telephone, using an address or phone number obtained directly from the Qualified Government Information Source, Qualified Governmental Tax Information Source or Registration Agency, or from a Qualified Independent Information Source. In addition, the CA MUST validate a Principal Individual associated with the Business Entity pursuant to the requirements in subsection (4), below.
 
 4. **Principal Individual**: A Principal Individual associated with the Business Entity MUST be validated in a face-to-face setting.  The CA MAY rely upon a face-to-face validation of the Principal Individual performed by the Registration Agency, provided that the CA has evaluated the validation procedure and concluded that it satisfies the requirements of the Guidelines for face-to-face validation procedures.  Where no face-to-face validation was conducted by the Registration Agency, or the Registration Agency's face-to-face validation procedure does not satisfy the requirements of the Guidelines, the CA SHALL perform face-to-face validation.
 
@@ -855,7 +507,7 @@ To verify the Applicant's legal existence and identity, the CA MUST do the follo
        i. the CA confirms their authenticity (not improperly modified when compared with the underlying original) with the Third-Party Validator; and
        ii. electronic copies of similar kinds of documents are recognized as legal substitutes for originals under the laws of the CA's jurisdiction.
 
-5. **Non-Commercial Entity Subjects (International Organization)**: Unless verified under subsection (6), all items listed in [Section 11.2.1](#1121-verification-requirements) (4) MUST be verified either:
+5. **Non-Commercial Entity Subjects (International Organization)**: Unless verified under subsection (6), all items listed in [Section 3.2.2.2.1](#32221-verification-requirements) (4) MUST be verified either:
 
    A.  With reference to the constituent document under which the International Organization was formed; or
    B.  Directly with a signatory country's government in which the CA is permitted to do business.  Such verification may be obtained from an appropriate government agency or from the laws of that country, or by verifying that the country's government has a mission to represent it at the International Organization; or
@@ -867,16 +519,16 @@ To verify the Applicant's legal existence and identity, the CA MUST do the follo
    i. the Verified Professional Letter includes a copy of supporting documentation used to establish the Applicant's legal existence, such as a certificate of registration, articles of incorporation, operating agreement, statute, or regulatory act, and
    ii. the CA confirms the Applicant's organization name specified in the Verified Professional Letter with a QIIS or QGIS.
 
-## 11.3. Verification of Applicant's Legal Existence and Identity – Assumed Name
+#### 3.2.2.3 Verification of Applicant's Legal Existence and Identity – Assumed Name
 
-### 11.3.1. Verification Requirements
+##### 3.2.2.3.1 Verification Requirements
 
 If, in addition to the Applicant's formal legal name, as recorded with the applicable Incorporating Agency or Registration Agency in the Applicant's Jurisdiction of Incorporation or Registration, the Applicant's identity, as asserted in the EV Certificate, is to contain any assumed name (also known as "doing business as", "DBA", or "d/b/a" in the US, and "trading as" in the UK) under which the Applicant conducts business, the CA MUST verify that:
 
    i. the Applicant has registered its use of the assumed name with the appropriate government agency for such filings in the jurisdiction of its Place of Business (as verified in accordance with these Guidelines), and
    ii. that such filing continues to be valid.
 
-### 11.3.2. Acceptable Method of Verification
+##### 3.2.2.3.2 Acceptable Method of Verification
 
 To verify any assumed name under which the Applicant conducts business:
 
@@ -884,17 +536,19 @@ To verify any assumed name under which the Applicant conducts business:
 2. The CA MAY verify the assumed name through use of a Qualified Independent Information Source provided that the QIIS has verified the assumed name with the appropriate government agency.
 3. The CA MAY rely on a Verified Professional Letter  that indicates the assumed name under which the Applicant conducts business, the government agency with which the assumed name is registered, and that such filing continues to be valid.
 
-## 11.4. Verification of Applicant's Physical Existence
+#### 3.2.2.4 Verification of Applicant's Physical Existence
 
-### 11.4.1. Address of Applicant's Place of Business
+##### 3.2.2.4.1 Address of Applicant's Place of Business
 
 1. **Verification Requirements**: To verify the Applicant's physical existence and business presence, the CA MUST verify that the physical address provided by the Applicant is an address where the Applicant or a Parent/Subsidiary Company conducts business operations (not, for example, a mail drop or P.O. box, or 'care of' (C/O) address, such as an address for an agent of the Organization), and is the address of the Applicant's Place of Business.
 
 2. **Acceptable Methods of Verification**
 
+
    A.  **Place of Business in the Country of Incorporation or Registration**
 
-       i. For Applicants whose Place of Business is in the same country as the Applicant's Jurisdiction of Incorporation or Registration and whose Place of Business is NOT the same as that indicated in the relevant Qualified Government Information Source used in [Section 11.2](#112-verification-of-applicants-legal-existence-and-identity) to verify legal existence:
+
+       i. For Applicants whose Place of Business is in the same country as the Applicant's Jurisdiction of Incorporation or Registration and whose Place of Business is NOT the same as that indicated in the relevant Qualified Government Information Source used in [Section 3.2.2.2](#3222-verification-of-applicants-legal-existence-and-identity) to verify legal existence:
 
           1. For Applicants listed at the same Place of Business address in the current version of either at least one QGIS (other than that used to verify legal existence), QIIS or QTIS, the CA MUST confirm that the Applicant's address, as listed in the EV Certificate Request, is a valid business address for the Applicant or a Parent/Subsidiary Company by reference to such QGIS, QIIS, or QTIS, and MAY rely on the Applicant's representation that such address is its Place of Business;
 
@@ -910,17 +564,17 @@ To verify any assumed name under which the Applicant conducts business:
 
        ii. For all Applicants, the CA MAY alternatively rely on a Verified Professional Letter that indicates the address of the Applicant's or a Parent/Subsidiary Company's Place of Business and that business operations are conducted there.
        iii. For Government Entity Applicants, the CA MAY rely on the address contained in the records of the QGIS in the Applicant's jurisdiction.
-       iv. For Applicants whose Place of Business is in the same country as the Applicant's Jurisdiction of Incorporation or Registration and where the QGIS used in [Section 11.2](#112-verification-of-applicants-legal-existence-and-identity) to verify legal existence contains a business address for the Applicant, the CA MAY rely on the address in the QGIS to confirm the Applicant's or a Parent/Subsidiary Company's address as listed in the EV Certificate Request, and MAY rely on the Applicant's representation that such address is its Place of Business.
+       iv. For Applicants whose Place of Business is in the same country as the Applicant's Jurisdiction of Incorporation or Registration and where the QGIS used in [Section 3.2.2.2](#3222-verification-of-applicants-legal-existence-and-identity) to verify legal existence contains a business address for the Applicant, the CA MAY rely on the address in the QGIS to confirm the Applicant's or a Parent/Subsidiary Company's address as listed in the EV Certificate Request, and MAY rely on the Applicant's representation that such address is its Place of Business.
 
    B.  **Place of Business not in the Country of Incorporation or Registration**: The CA MUST rely on a Verified Professional Letter that indicates the address of the Applicant's Place of Business and that business operations are conducted there.
 
-## 11.5. Verified Method of Communication
+#### 3.2.2.5 Verified Method of Communication
 
-### 11.5.1. Verification Requirements
+##### 3.2.2.5.1 Verification Requirements
 
 To assist in communicating with the Applicant and confirming that the Applicant is aware of and approves issuance, the CA MUST verify a telephone number, fax number, email address, or postal delivery address as a Verified Method of Communication with the Applicant.
 
-### 11.5.2. Acceptable Methods of Verification
+##### 3.2.2.5.2 Acceptable Methods of Verification
 
 To verify a Verified Method of Communication with the Applicant, the CA MUST:
 
@@ -932,13 +586,13 @@ A.  Verify that the Verified Method of Communication belongs to the Applicant, o
 
 B.  Confirm the Verified Method of Communication by using it to obtain an affirmative response sufficient to enable a reasonable person to conclude that the Applicant, or a Parent/Subsidiary or Affiliate of Applicant, can be contacted reliably by using the Verified Method of Communication.
 
-## 11.6. Verification of Applicant's Operational Existence
+#### 3.2.2.6 Verification of Applicant's Operational Existence
 
-### 11.6.1. Verification Requirements
+##### 3.2.2.6.1 Verification Requirements
 
-The CA MUST verify that the Applicant has the ability to engage in business by verifying the Applicant's, or Affiliate/Parent/Subsidiary Company's, operational existence.  The CA MAY rely on its verification of a Government Entity's legal existence under [Section 11.2](#112-verification-of-applicants-legal-existence-and-identity) as verification of a Government Entity's operational existence.
+The CA MUST verify that the Applicant has the ability to engage in business by verifying the Applicant's, or Affiliate/Parent/Subsidiary Company's, operational existence.  The CA MAY rely on its verification of a Government Entity's legal existence under [Section 3.2.2.2](#3222-verification-of-applicants-legal-existence-and-identity) as verification of a Government Entity's operational existence.
 
-### 11.6.2. Acceptable Methods of Verification
+##### 3.2.2.6.2 Acceptable Methods of Verification
 
 To verify the Applicant's ability to engage in business, the CA MUST verify the operational existence of the Applicant, or its Affiliate/Parent/Subsidiary Company, by:
 
@@ -950,17 +604,17 @@ To verify the Applicant's ability to engage in business, the CA MUST verify the 
 
 4. Relying on a Verified Professional Letter to the effect that the Applicant has an active current Demand Deposit Account with a Regulated Financial Institution.
 
-## 11.7. Verification of Applicant's Domain Name
+##### 3.2.2.7 Verification of Applicant's Domain Name
 
-### 11.7.1. Verification Requirements
+##### 3.2.2.7.1 Verification Requirements
 
 1. For each Fully-Qualified Domain Name listed in a Certificate which is not an Onion Domain Name, the CA SHALL confirm that, as of the date the Certificate was issued, the Applicant (or the Applicant's Parent Company, Subsidiary Company, or Affiliate, collectively referred to as "Applicant" for the purposes of this section) either is the Domain Name Registrant or has control over the FQDN using a procedure specified in Section 3.2.2.4 of the Baseline Requirements. For a Certificate issued to an Onion Domain Name, the CA SHALL confirm that, as of the date the Certificate was issued, the Applicant's control over the Onion Domain Name in accordance with Appendix B of the Baseline Requirements.
 
 2. **Mixed Character Set Domain Names**: EV Certificates MAY include Domain Names containing mixed character sets only in compliance with the rules set forth by the domain registrar.  The CA MUST visually compare any Domain Names with mixed character sets with known high risk domains.  If a similarity is found, then the EV Certificate Request MUST be flagged as High Risk.  The CA must perform reasonably appropriate additional authentication and verification to be certain beyond reasonable doubt that the Applicant and the target in question are the same organization.
 
-## 11.8. Verification of Name, Title, and Authority of Contract Signer and Certificate Approver
+#### 3.2.2.8 Verification of Name, Title, and Authority of Contract Signer and Certificate Approver
 
-### 11.8.1. Verification Requirements
+##### 3.2.2.8.1 Verification Requirements
 
 For both the Contract Signer and the Certificate Approver, the CA MUST verify the following.
 
@@ -972,7 +626,7 @@ For both the Contract Signer and the Certificate Approver, the CA MUST verify th
    B.  Provide, and, if applicable, authorize a Certificate Requester to provide, the information requested from the Applicant by the CA for issuance of the EV Certificate; and
    C.  Approve EV Certificate Requests submitted by a Certificate Requester.
 
-### 11.8.2. Acceptable Methods of Verification – Name, Title and Agency
+##### 3.2.2.8.2 Acceptable Methods of Verification – Name, Title and Agency
 
 Acceptable methods of verification of the name, title, and agency status of the Contract Signer and the Certificate Approver include the following.
 
@@ -981,12 +635,12 @@ Acceptable methods of verification of the name, title, and agency status of the 
 2. **Agency**: The CA MAY verify the agency of the Contract Signer and the Certificate Approver by:
 
    A.  Contacting the Applicant using a Verified Method of Communication for the Applicant, and obtaining confirmation that the Contract Signer and/or the Certificate Approver, as applicable, is an employee;
-   B.  Obtaining an Independent Confirmation From the Applicant (as described in [Section 11.11.4](#11114-independent-confirmation-from-applicant)), or a Verified Professional Letter verifying that the Contract Signer and/or the Certificate Approver, as applicable, is either an employee or has otherwise been appointed as an agent of the Applicant; or
+   B.  Obtaining an Independent Confirmation From the Applicant (as described in [Section 3.2.2.11.4](#322114-independent-confirmation-from-applicant)), or a Verified Professional Letter verifying that the Contract Signer and/or the Certificate Approver, as applicable, is either an employee or has otherwise been appointed as an agent of the Applicant; or
    C.  Obtaining confirmation from a QIIS or QGIS that the Contract Signer and/or Certificate Approver is an employee of the Applicant.
 
    The CA MAY also verify the agency of the Certificate Approver via a certification from the Contract Signer (including in a contract between the CA and the Applicant signed by the Contract Signer), provided that the employment or agency status and Signing Authority of the Contract Signer has been verified.
 
-### 11.8.3. Acceptable Methods of Verification – Authority
+##### 3.2.2.8.3 Acceptable Methods of Verification – Authority
 
 Acceptable methods of verification of the Signing Authority of the Contract Signer, and the EV Authority of the Certificate Approver, as applicable, include:
 
@@ -996,7 +650,7 @@ Acceptable methods of verification of the Signing Authority of the Contract Sign
    i. certified by the appropriate corporate officer (e.g., secretary), and
    ii. the CA can reliably verify that the certification was validly signed by such person, and that such person does have the requisite authority to provide such certification;
 
-3. **Independent Confirmation from Applicant**: The Signing Authority of the Contract Signer, and/or the EV Authority of the Certificate Approver, MAY be verified by obtaining an Independent Confirmation from the Applicant (as described in [Section 11.11.4](#11114-independent-confirmation-from-applicant));
+3. **Independent Confirmation from Applicant**: The Signing Authority of the Contract Signer, and/or the EV Authority of the Certificate Approver, MAY be verified by obtaining an Independent Confirmation from the Applicant (as described in [Section 3.2.2.11.4](#322114-independent-confirmation-from-applicant));
 4. **Contract between CA and Applicant**: The EV Authority of the Certificate Approver MAY be verified by reliance on a contract between the CA and the Applicant that designates the Certificate Approver with such EV Authority, provided that the contract is signed by the Contract Signer and provided that the agency and Signing Authority of the Contract Signer have been verified;
 5. **Prior Equivalent Authority**: The signing authority of the Contract Signer, and/or the EV authority of the Certificate Approver, MAY be verified by relying on a demonstration of Prior Equivalent Authority.
 
@@ -1024,13 +678,13 @@ Acceptable methods of verification of the Signing Authority of the Contract Sign
 
 Note: An example of an acceptable representation/warranty appears in [Appendix E](#appendix-e---sample-contract-signers-representationwarranty-informative).
 
-### 11.8.4. Pre-Authorized Certificate Approver
+##### 3.2.2.8.4 Pre-Authorized Certificate Approver
 
 Where the CA and Applicant contemplate the submission of multiple future EV Certificate Requests, then, after the CA:
 
 1. Has verified the name and title of the Contract Signer and that he/she is an employee or agent of the Applicant; and
 
-2. Has verified the Signing Authority of such Contract Signer in accordance with one of the procedures in [Section 11.8.3](#1183-acceptable-methods-of-verification--authority).
+2. Has verified the Signing Authority of such Contract Signer in accordance with one of the procedures in [Section 3.2.2.8.3](#32283-acceptable-methods-of-verification--authority).
 
 The CA and the Applicant MAY enter into a written agreement, signed by the Contract Signer on behalf of the Applicant, whereby, for a specified term, the Applicant expressly authorizes one or more Certificate Approver(s) designated in such agreement to exercise EV Authority with respect to each future EV Certificate Request submitted on behalf of the Applicant and properly authenticated as originating with, or otherwise being approved by, such Certificate Approver(s).
 
@@ -1041,17 +695,17 @@ Such an agreement MUST provide that the Applicant shall be obligated under the S
    iii. secure procedures by which the Applicant can notify the CA that the EV Authority of any such Certificate Approver is revoked, and
    iv. such other appropriate precautions as are reasonably necessary.
 
-## 11.9. Verification of Signature on Subscriber Agreement and EV Certificate Requests
+#### 3.2.2.9 Verification of Signature on Subscriber Agreement and EV Certificate Requests
 
-Both the Subscriber Agreement and each non-pre-authorized EV Certificate Request MUST be signed.  The Subscriber Agreement MUST be signed by an authorized Contract Signer.  The EV Certificate Request MUST be signed by the Certificate Requester submitting the document, unless the Certificate Request has been pre-authorized in line with [Section 11.8.4](#1184-pre-authorized-certificate-approver).  If the Certificate Requester is not also an authorized Certificate Approver, then an authorized Certificate Approver MUST independently approve the EV Certificate Request.  In all cases, applicable signatures MUST be a legally valid and contain an enforceable seal or handwritten signature (for a paper Subscriber Agreement and/or EV Certificate Request), or a legally valid and enforceable electronic signature (for an electronic Subscriber Agreement and/or EV Certificate Request), that binds the Applicant to the terms of each respective document.
+Both the Subscriber Agreement and each non-pre-authorized EV Certificate Request MUST be signed.  The Subscriber Agreement MUST be signed by an authorized Contract Signer.  The EV Certificate Request MUST be signed by the Certificate Requester submitting the document, unless the Certificate Request has been pre-authorized in line with [Section 3.2.2.8.4](#32284-pre-authorized-certificate-approver).  If the Certificate Requester is not also an authorized Certificate Approver, then an authorized Certificate Approver MUST independently approve the EV Certificate Request.  In all cases, applicable signatures MUST be a legally valid and contain an enforceable seal or handwritten signature (for a paper Subscriber Agreement and/or EV Certificate Request), or a legally valid and enforceable electronic signature (for an electronic Subscriber Agreement and/or EV Certificate Request), that binds the Applicant to the terms of each respective document.
 
-### 11.9.1. Verification Requirements
+##### 3.2.2.9.1 Verification Requirements
 
 1. **Signature**: The CA MUST authenticate the signature of the Contract Signer on the Subscriber Agreement and the signature of the Certificate Requester on each EV Certificate Request in a manner that makes it reasonably certain that the person named as the signer in the applicable document is, in fact, the person who signed the document on behalf of the Applicant.
 
-2. **Approval Alternative**: In cases where an EV Certificate Request is signed and submitted by a Certificate Requester who does not also function as a Certificate Approver, approval and adoption of the EV Certificate Request by a Certificate Approver in accordance with the requirements of [Section 11.10](#1110-verification-of-approval-of-ev-certificate-request) can substitute for authentication of the signature of the Certificate Requester on such EV Certificate Request.
+2. **Approval Alternative**: In cases where an EV Certificate Request is signed and submitted by a Certificate Requester who does not also function as a Certificate Approver, approval and adoption of the EV Certificate Request by a Certificate Approver in accordance with the requirements of [Section 3.2.2.10](#32210-verification-of-approval-of-ev-certificate-request) can substitute for authentication of the signature of the Certificate Requester on such EV Certificate Request.
 
-### 11.9.2. Acceptable Methods of Signature Verification
+##### 3.2.2.9.2 Acceptable Methods of Signature Verification
 
 Acceptable methods of authenticating the signature of the Certificate Requester or Contract Signer include the following:
 
@@ -1063,23 +717,23 @@ Acceptable methods of authenticating the signature of the Certificate Requester 
 
 4. Notarization by a notary, provided that the CA independently verifies that such notary is a legally qualified notary in the jurisdiction of the Certificate Requester or Contract Signer.
 
-## 11.10. Verification of Approval of EV Certificate Request
+#### 3.2.2.10 Verification of Approval of EV Certificate Request
 
-### 11.10.1. Verification Requirements
+##### 3.2.2.10.1 Verification Requirements
 
 In cases where an EV Certificate Request is submitted by a Certificate Requester, before the CA issues the requested EV Certificate, the CA MUST verify that an authorized Certificate Approver reviewed and approved the EV Certificate Request.
 
-### 11.10.2. Acceptable Methods of Verification
+##### 3.2.2.10.2 Acceptable Methods of Verification
 
 Acceptable methods of verifying the Certificate Approver's approval of an EV Certificate Request include:
 
 1. Contacting the Certificate Approver using a Verified Method of Communication for the Applicant and obtaining oral or written confirmation that the Certificate Approver has reviewed and approved the EV Certificate Request;
 2. Notifying the Certificate Approver that one or more new EV Certificate Requests are available for review and approval at a designated access-controlled and secure Web site, followed by a login by, and an indication of approval from, the Certificate Approver in the manner required by the Web site; or
-3. Verifying the signature of the Certificate Approver on the EV Certificate Request in accordance with [Section 11.9](#119-verification-of-signature-on-subscriber-agreement-and-ev-certificate-requests).
+3. Verifying the signature of the Certificate Approver on the EV Certificate Request in accordance with [Section 3.2.2.9](#3229-verification-of-signature-on-subscriber-agreement-and-ev-certificate-requests).
 
-## 11.11. Verification of Certain Information Sources
+#### 3.2.2.11 Verification of Certain Information Sources
 
-### 11.11.1. Verified Legal Opinion
+##### 3.2.2.11.1 Verified Legal Opinion
 
 1. **Verification Requirements**: Before relying on a legal opinion submitted to the CA, the CA MUST verify that such legal opinion meets the following requirements:
 
@@ -1097,9 +751,9 @@ Acceptable methods of verifying the Certificate Approver's approval of an EV Cer
    B.  **Basis of Opinion**: The text of the legal opinion MUST make it clear that the Legal Practitioner is acting on behalf of the Applicant and that the conclusions of the legal opinion are based on the Legal Practitioner's stated familiarity with the relevant facts and the exercise of the practitioner's professional judgment and expertise.  The legal opinion MAY also include disclaimers and other limitations customary in the Legal Practitioner's jurisdiction, provided that the scope of the disclaimed responsibility is not so great as to eliminate any substantial risk (financial, professional, and/or reputational) to the Legal Practitioner, should the legal opinion prove to be erroneous.  An acceptable form of legal opinion is attached as [Appendix B](#appendix-b---sample-attorney-opinions-confirming-specified-information);
    C.  **Authenticity**: To confirm the authenticity of the legal opinion, the CA MUST make a telephone call or send a copy of the legal opinion back to the Legal Practitioner at the address, phone number, facsimile, or (if available) e-mail address for the Legal Practitioner listed with the authority responsible for registering or licensing such Legal Practitioner, and obtain confirmation from the Legal Practitioner or the Legal Practitioner's assistant that the legal opinion is authentic.  If a phone number is not available from the licensing authority, the CA MAY use the number listed for the Legal Practitioner in records provided by the applicable phone company, QGIS, or QIIS.
 
-       In circumstances where the opinion is digitally signed, in a manner that confirms the authenticity of the document and the identity of the signer, as verified by the CA in [Section 11.11.1](#11111-verified-legal-opinion) (2)(A), no further verification of authenticity is required.
+       In circumstances where the opinion is digitally signed, in a manner that confirms the authenticity of the document and the identity of the signer, as verified by the CA in [Section 3.2.2.11.1](#322111-verified-legal-opinion) (2)(A), no further verification of authenticity is required.
 
-### 11.11.2. Verified Accountant Letter
+##### 3.2.2.11.2 Verified Accountant Letter
 
 1. **Verification Requirements**: Before relying on an accountant letter submitted to the CA, the CA MUST verify that such accountant letter meets the following requirements:
 
@@ -1113,9 +767,9 @@ Acceptable methods of verifying the Certificate Approver's approval of an EV Cer
    B.  **Basis of Opinion**: The text of the Verified Accountant Letter MUST make clear that the Accounting Practitioner is acting on behalf of the Applicant and that the information in the letter is based on the Accounting Practitioner's stated familiarity with the relevant facts and the exercise of the practitioner's professional judgment and expertise.  The Verified Accountant Letter MAY also include disclaimers and other limitations customary in the Accounting Practitioner's jurisdiction, provided that the scope of the disclaimed responsibility is not so great as to eliminate any substantial risk (financial, professional, and/or reputational) to the Accounting Practitioner, should the Verified Accountant Letter prove to be erroneous.  Acceptable forms of Verified Accountant Letter are attached as [Appendix C](#appendix-c---sample-accountant-letters-confirming-specified-information).
    C.  **Authenticity**: To confirm the authenticity of the accountant's opinion, the CA MUST make a telephone call or send a copy of the Verified Accountant Letter back to the Accounting Practitioner at the address, phone number, facsimile, or (if available) e-mail address for the Accounting Practitioner listed with the authority responsible for registering or licensing such Accounting Practitioners and obtain confirmation from the Accounting Practitioner or the Accounting Practitioner's assistant that the accountant letter is authentic.  If a phone number is not available from the licensing authority, the CA MAY use the number listed for the Accountant in records provided by the applicable phone company, QGIS, or QIIS.
 
-      In circumstances where the opinion is digitally signed, in a manner that confirms the authenticity of the document and the identity of the signer, as verified by the CA in [Section 11.11.2](#11112-verified-accountant-letter) (2)(A), no further verification of authenticity is required.
+      In circumstances where the opinion is digitally signed, in a manner that confirms the authenticity of the document and the identity of the signer, as verified by the CA in [Section 3.2.2.11.2](#322112-verified-accountant-letter) (2)(A), no further verification of authenticity is required.
 
-### 11.11.3. Face-to-Face Validation
+##### 3.2.2.11.3 Face-to-Face Validation
 
 1. **Verification Requirements**: Before relying on face-to-face vetting documents submitted to the CA, the CA MUST verify that the Third-Party Validator meets the following requirements:
 
@@ -1127,9 +781,9 @@ Acceptable methods of verifying the Certificate Approver's approval of an EV Cer
 
    A.  **Qualification of Third-Party Validator**: The CA MUST verify the professional status of the Third-Party Validator by directly contacting the authority responsible for registering or licensing such Third-Party Validators in the applicable jurisdiction;
    B.  **Document Chain of Custody**: The Third-Party Validator MUST submit a statement to the CA which attests that they obtained the Vetting Documents submitted to the CA for the individual during a face-to-face meeting with the individual;
-   C.  **Verification of Attestation**: If the Third-Party Validator is not a Latin Notary, then the CA MUST confirm the authenticity of the vetting documents received from the Third-Party Validator.  The CA MUST make a telephone call to the Third-Party Validator and obtain confirmation from them or their assistant that they performed the face-to-face validation.  The CA MAY rely upon self-reported information obtained from the Third-Party Validator for the sole purpose of performing this verification process.  In circumstances where the attestation is digitally signed, in a manner that confirms the authenticity of the documents, and the identity of the signer as verified by the CA in [Section 11.11.3](#11113-face-to-face-validation) (1)(A), no further verification of authenticity is required.
+   C.  **Verification of Attestation**: If the Third-Party Validator is not a Latin Notary, then the CA MUST confirm the authenticity of the vetting documents received from the Third-Party Validator.  The CA MUST make a telephone call to the Third-Party Validator and obtain confirmation from them or their assistant that they performed the face-to-face validation.  The CA MAY rely upon self-reported information obtained from the Third-Party Validator for the sole purpose of performing this verification process.  In circumstances where the attestation is digitally signed, in a manner that confirms the authenticity of the documents, and the identity of the signer as verified by the CA in [Section 3.2.2.11.3](#322113-face-to-face-validation) (1)(A), no further verification of authenticity is required.
 
-### 11.11.4. Independent Confirmation From Applicant
+##### 3.2.2.11.4 Independent Confirmation From Applicant
 
 An Independent Confirmation from the Applicant is a confirmation of a particular fact (e.g., confirmation of the employee or agency status of a Contract Signer or Certificate Approver, confirmation of the EV Authority of a Certificate Approver, etc.) that is:
 
@@ -1166,7 +820,7 @@ An Independent Confirmation from the Applicant MAY be obtained via the following
    A.  The domain of the e-mail address is owned by the Applicant and is the Confirming Person's own e-mail address and not a group e-mail alias;
    B.  The Confirming Person's telephone/fax number is verified by the CA to be a telephone number that is part of the organization's telephone system, and is not the personal phone number for the person.
 
-### 11.11.5. Qualified Independent Information Source
+##### 3.2.2.11.5 Qualified Independent Information Source
 
 A Qualified Independent Information Source (QIIS) is a regularly-updated and publicly available database that is generally recognized as a dependable source for certain information.  A database qualifies as a QIIS if the CA determines that:
 
@@ -1181,21 +835,21 @@ The CA SHALL use a documented process to check the accuracy of the database and 
 
 Databases in which the CA or its owners or affiliated companies maintain a controlling interest, or in which any Registration Authorities or subcontractors to whom the CA has outsourced any portion of the vetting process (or their owners or affiliated companies) maintain any ownership or beneficial interest, do not qualify as a QIIS.
 
-### 11.11.6. Qualified Government Information Source
+##### 3.2.2.11.6 Qualified Government Information Source
 
 A Qualified Government Information Source (QGIS) is a regularly-updated and current, publicly available, database designed for the purpose of accurately providing the information for which it is consulted, and which is generally recognized as a dependable source of such information provided that it is maintained by a Government Entity, the reporting of data is required by law, and false or misleading reporting is punishable with criminal or civil penalties. Nothing in these Guidelines shall prohibit the use of third-party vendors to obtain the information from the Government Entity provided that the third party obtains the information directly from the Government Entity.
 
-### 11.11.7. Qualified Government Tax Information Source
+##### 3.2.2.11.7 Qualified Government Tax Information Source
 
 A Qualified Government Tax Information Source is a Qualified Government Information Source that specifically contains tax information relating to Private Organizations, Business Entities or Individuals (e.g., the IRS in the United States).
 
-## 11.12. Other Verification Requirements
+#### 3.2.2.12 Other Verification Requirements
 
-### 11.12.1. High Risk Status
+##### 3.2.2.12.1 High Risk Status
 
 The High Risk Certificate requirements of Section 4.2.1 of the Baseline Requirements apply equally to EV Certificates.
 
-### 11.12.2. Denied Lists and Other Legal Block Lists
+##### 3.2.2.12.2 Denied Lists and Other Legal Block Lists
 
 1. **Verification Requirements**: The CA MUST verify whether the Applicant, the Contract Signer, the Certificate Approver, the Applicant's Jurisdiction of Incorporation, Registration, or Place of Business:
 
@@ -1215,12 +869,12 @@ The High Risk Certificate requirements of Section 4.2.1 of the Baseline Requirem
 
    B.  If the CA has operations in any other country, the CA MUST take reasonable steps to verify with all equivalent denied lists and export regulations (if any) in such other country.
 
-### 11.12.3. Parent/Subsidiary/Affiliate Relationship
+##### 3.2.2.12.3 Parent/Subsidiary/Affiliate Relationship
 
-A CA verifying an Applicant using information of the Applicant's Parent, Subsidiary, or Affiliate, when allowed under [Section 11.4.1](#1141-address-of-applicants-place-of-business), [Section 11.5](#115-verified-method-of-communication), [Section 11.6.1](#1161-verification-requirements), or [Section 11.7.1](#1171-verification-requirements), MUST verify the Applicant's relationship to the Parent, Subsidiary, or Affiliate. Acceptable methods of verifying the Applicant's relationship to the Parent, Subsidiary, or Affiliate include the following:
+A CA verifying an Applicant using information of the Applicant's Parent, Subsidiary, or Affiliate, when allowed under [Section 3.2.2.4.1](#32241-address-of-applicants-place-of-business), [Section 3.2.2.5](#3225-verified-method-of-communication), [Section 3.2.2.6.1](#32261-verification-requirements), or [Section 3.2.2.7.1](#32271-verification-requirements), MUST verify the Applicant's relationship to the Parent, Subsidiary, or Affiliate. Acceptable methods of verifying the Applicant's relationship to the Parent, Subsidiary, or Affiliate include the following:
 
 1. QIIS or QGIS: The relationship between the Applicant and the Parent, Subsidiary, or Affiliate is identified in a QIIS or QGIS;
-2. Independent Confirmation from the Parent, Subsidiary, or Affiliate: A CA MAY verify the relationship between an Applicant and a Parent, Subsidiary, or Affiliate by obtaining an Independent Confirmation from the appropriate Parent, Subsidiary, or Affiliate (as described in [Section 11.11.4](#11114-independent-confirmation-from-applicant));
+2. Independent Confirmation from the Parent, Subsidiary, or Affiliate: A CA MAY verify the relationship between an Applicant and a Parent, Subsidiary, or Affiliate by obtaining an Independent Confirmation from the appropriate Parent, Subsidiary, or Affiliate (as described in [Section 3.2.2.11.4](#322114-independent-confirmation-from-applicant));
 3. Contract between CA and Parent, Subsidiary, or Affiliate: A CA MAY verify the relationship between an Applicant and a Parent, Subsidiary, or Affiliate by relying on a contract between the CA and the Parent, Subsidiary, or Affiliate that designates the Certificate Approver with such EV Authority, provided that the contract is signed by the Contract Signer and provided that the agency and Signing Authority of the Contract Signer have been verified;
 4. Verified Professional Letter: A CA MAY verify the relationship between an Applicant and a Parent, Subsidiary, or Affiliate by relying on a Verified Professional Letter; or
 5. Corporate Resolution: A CA MAY verify the relationship between an Applicant and a Subsidiary by relying on a properly authenticated corporate resolution that approves creation of the Subsidiary or the Applicant, provided that such resolution is:
@@ -1228,44 +882,44 @@ A CA verifying an Applicant using information of the Applicant's Parent, Subsidi
    i. certified by the appropriate corporate officer (e.g., secretary), and
    ii. the CA can reliably verify that the certification was validly signed by such person, and that such person does have the requisite authority to provide such certification.
 
-## 11.13. Final Cross-Correlation and Due Diligence
+#### 3.2.2.13 Final Cross-Correlation and Due Diligence
 
 1. The results of the verification processes and procedures outlined in these Guidelines are intended to be viewed both individually and as a group.  Thus, after all of the verification processes and procedures are completed, the CA MUST have a person who is not responsible for the collection of information review all of the information and documentation assembled in support of the EV Certificate application and look for discrepancies or other details requiring further explanation.
 2. The CA MUST obtain and document further explanation or clarification from the Applicant, Certificate Approver, Certificate Requester, Qualified Independent Information Sources, and/or other sources of information, as necessary, to resolve those discrepancies or details that require further explanation.
 3. The CA MUST refrain from issuing an EV Certificate until the entire corpus of information and documentation assembled in support of the EV Certificate Request is such that issuance of the EV Certificate will not communicate factual information that the CA knows, or the exercise of due diligence should discover from the assembled information and documentation, to be inaccurate,.  If satisfactory explanation and/or additional documentation are not received within a reasonable time, the CA MUST decline the EV Certificate Request and SHOULD notify the Applicant accordingly.
-4. In the case where some or all of the documentation used to support the application is in a language other than the CA's normal operating language, the CA or its Affiliate MUST perform the requirements of this Final Cross-Correlation and Due Diligence section using employees under its control and having appropriate training, experience, and judgment in confirming organizational identification and authorization and fulfilling all qualification requirements contained in [Section 14.1](#141-trustworthiness-and-competence).  When employees under the control of the CA do not possess the language skills necessary to perform the Final Cross-Correlation and Due Diligence a CA MAY:
+4. In the case where some or all of the documentation used to support the application is in a language other than the CA's normal operating language, the CA or its Affiliate MUST perform the requirements of this Final Cross-Correlation and Due Diligence section using employees under its control and having appropriate training, experience, and judgment in confirming organizational identification and authorization and fulfilling all qualification requirements contained in [Section 5.3.2](#532-background-check-procedures).  When employees under the control of the CA do not possess the language skills necessary to perform the Final Cross-Correlation and Due Diligence a CA MAY:
 
    A.  Rely on language translations of the relevant portions of the documentation, provided that the translations are received from a Translator; or
-   B.  When the CA has utilized the services of an RA, the CA MAY rely on the language skills of the RA to perform the Final Cross-Correlation and Due Diligence, provided that the RA complies with [Section 11.13](#1113-final-cross-correlation-and-due-diligence), Subsections (1), (2) and (3).  Notwithstanding the foregoing, prior to issuing the EV Certificate, the CA MUST review the work completed by the RA and determine that all requirements have been met; or
-   C.  When the CA has utilized the services of an RA, the CA MAY rely on the RA to perform the Final Cross-Correlation and Due Diligence, provided that the RA complies with this section and is subjected to the Audit Requirements of [Section 17.5](#175-regular-self-audits) and [Section 17.6](#176-auditor-qualification).
+   B.  When the CA has utilized the services of an RA, the CA MAY rely on the language skills of the RA to perform the Final Cross-Correlation and Due Diligence, provided that the RA complies with [Section 3.2.2.13](#32213-final-cross-correlation-and-due-diligence), Subsections (1), (2) and (3).  Notwithstanding the foregoing, prior to issuing the EV Certificate, the CA MUST review the work completed by the RA and determine that all requirements have been met; or
+   C.  When the CA has utilized the services of an RA, the CA MAY rely on the RA to perform the Final Cross-Correlation and Due Diligence, provided that the RA complies with this section and is subjected to the Audit Requirements of [Section 8.1.1](#811-self-audits) and [Section 8.2](#82-identityqualifications-of-assessor).
 
-In the case of EV Certificates to be issued in compliance with the requirements of [Section 14.2](#142-delegation-of-functions-to-registration-authorities-and-subcontractors), the Enterprise RA MAY perform the requirements of this Final Cross-Correlation and Due Diligence section.
+In the case of EV Certificates to be issued in compliance with the requirements of [Section 1.3.2](#132-registration-authorities), the Enterprise RA MAY perform the requirements of this Final Cross-Correlation and Due Diligence section.
 
-## 11.14. Requirements for Re-use of Existing Documentation
+#### 3.2.2.14 Requirements for Re-use of Existing Documentation
 
 For each EV Certificate Request, including requests to renew existing EV Certificates, the CA MUST perform all authentication and verification tasks required by these Guidelines to ensure that the request is properly authorized by the Applicant and that the information in the EV Certificate is still accurate and valid. This section sets forth the age limitations on for the use of documentation collected by the CA.
 
-### 11.14.1. Validation For Existing Subscribers
+##### 3.2.2.14.1 Validation For Existing Subscribers
 
 If an Applicant has a currently valid EV Certificate issued by the CA, a CA MAY rely on its prior authentication and verification of:
 
-1. The Principal Individual verified under [Section 11.2.2](#1122-acceptable-method-of-verification) (4) if the individual is the same person as verified by the CA in connection with the Applicant's previously issued and currently valid EV Certificate;
-2. The Applicant's Place of Business under [Section 11.4.1](#1141-address-of-applicants-place-of-business);
-3. The Applicant's Verified Method of Communication required by [Section 11.5](#115-verified-method-of-communication) but still MUST perform the verification required by [Section 11.5.2](#1152-acceptable-methods-of-verification) (B);
-4. The Applicant's Operational Existence under [Section 11.6](#116-verification-of-applicants-operational-existence);
-5. The Name, Title, Agency and Authority of the Contract Signer, and Certificate Approver, under [Section 11.8](#118-verification-of-name-title-and-authority-of-contract-signer-and-certificate-approver); and
-6. The Applicant's right to use the specified Domain Name under [Section 11.7](#117-verification-of-applicants-domain-name), provided that the CA verifies that the WHOIS record still shows the same registrant as when the CA verified the specified Domain Name for the initial EV Certificate.
+1. The Principal Individual verified under [Section 3.2.2.2.2](#32222-acceptable-method-of-verification) (4) if the individual is the same person as verified by the CA in connection with the Applicant's previously issued and currently valid EV Certificate;
+2. The Applicant's Place of Business under [Section 3.2.2.4.1](#32241-address-of-applicants-place-of-business);
+3. The Applicant's Verified Method of Communication required by [Section 3.2.2.5](#3225-verified-method-of-communication) but still MUST perform the verification required by [Section 3.2.2.5.2](#32252-acceptable-methods-of-verification) (B);
+4. The Applicant's Operational Existence under [Section 3.2.2.6](#3226-verification-of-applicants-operational-existence);
+5. The Name, Title, Agency and Authority of the Contract Signer, and Certificate Approver, under [Section 3.2.2.8](#3228-verification-of-name-title-and-authority-of-contract-signer-and-certificate-approver); and
+6. The Applicant's right to use the specified Domain Name under [Section 3.2.2.7](#3227-verification-of-applicants-domain-name), provided that the CA verifies that the WHOIS record still shows the same registrant as when the CA verified the specified Domain Name for the initial EV Certificate.
 
-### 11.14.2. Re-issuance Requests
+##### 3.2.2.14.2 Re-issuance Requests
 
 A CA may rely on a previously verified certificate request to issue a replacement certificate, so long as the certificate being referenced was not revoked due to fraud or other illegal conduct, if:
 
 1. The expiration date of the replacement certificate is the same as the expiration date of the  EV Certificate that is being replaced, and
 2. The Subject Information of the Certificate is the same as the Subject in the EV Certificate that is being replaced.
 
-### 11.14.3. Age of Validated Data
+##### 3.2.2.14.3 Age of Validated Data
 
-1. Except for reissuance of an EV Certificate under [Section 11.14.2](#11142-re-issuance-requests) and except when permitted otherwise in [Section 11.14.1](#11141-validation-for-existing-subscribers), the age of all data used to support issuance of an EV Certificate (before revalidation is required) SHALL NOT exceed the following limits:
+1. Except for reissuance of an EV Certificate under [Section 3.2.2.14.2](#322142-re-issuance-requests) and except when permitted otherwise in [Section 3.2.2.14.1](#322141-validation-for-existing-subscribers), the age of all data used to support issuance of an EV Certificate (before revalidation is required) SHALL NOT exceed the following limits:
 
    A.  Legal existence and identity – 398 days;
    B.  Assumed name – 398 days;
@@ -1276,25 +930,209 @@ A CA may rely on a previously verified certificate request to issue a replacemen
    G.  Name, Title, Agency, and Authority – 398 days, unless a contract between the CA and the Applicant specifies a different term, in which case, the term specified in such contract controls.  For example, the contract MAY include the perpetual assignment of EV roles until revoked by the Applicant or CA, or until the contract expires or is terminated.
 
 2. The 398-day period set forth above SHALL begin to run on the date the information was collected by the CA.
-3. The CA MAY reuse a previously submitted EV Certificate Request, Subscriber Agreement, or Terms of Use, including use of a single EV Certificate Request in support of multiple EV Certificates containing the same Subject to the extent permitted under [Section 11.9](#119-verification-of-signature-on-subscriber-agreement-and-ev-certificate-requests) and [Section 11.10](#1110-verification-of-approval-of-ev-certificate-request).
-4. The CA MUST repeat the verification process required in these Guidelines for any information obtained outside the time limits specified above except when permitted otherwise under [Section 11.14.1](#11141-validation-for-existing-subscribers).
+3. The CA MAY reuse a previously submitted EV Certificate Request, Subscriber Agreement, or Terms of Use, including use of a single EV Certificate Request in support of multiple EV Certificates containing the same Subject to the extent permitted under [Section 3.2.2.9](#3229-verification-of-signature-on-subscriber-agreement-and-ev-certificate-requests) and [Section 3.2.2.10](#32210-verification-of-approval-of-ev-certificate-request).
+4. The CA MUST repeat the verification process required in these Guidelines for any information obtained outside the time limits specified above except when permitted otherwise under [Section 3.2.2.14.1](#322141-validation-for-existing-subscribers).
 
-# 12. Certificate Issuance by a Root CA
+### 3.2.3  Authentication of individual identity 
+### 3.2.4  Non-verified subscriber information 
+### 3.2.5  Validation of authority
+### 3.2.6  Criteria for interoperation
 
+## 3.3  Identification and authentication for re-key requests
+### 3.3.1  Identification and authentication for routine re-key
+### 3.3.2  Identification and authentication for re-key after revocation
+
+## 3.4 Identification and authentication for revocation request
+
+# 4.  CERTIFICATE LIFE-CYCLE OPERATIONAL REQUIREMENTS
+
+## 4.1  Certificate Application
+
+### 4.1.1  Who can submit a certificate application
+The CA MAY only issue EV Certificates to Applicants that meet the Private Organization, Government Entity, Business Entity and Non-Commercial Entity requirements specified below.
+
+#### 4.1.1.1 Private Organization Subjects
+
+An Applicant qualifies as a Private Organization if:
+
+1. The entity's legal existence is created or recognized by a by a filing with (or an act of) the Incorporating or Registration Agency in its Jurisdiction of Incorporation or Registration (e.g., by issuance of a certificate of incorporation, registration number, etc.) or created or recognized by a Government Agency (e.g. under a charter, treaty, convention, or equivalent recognition instrument);
+
+2. The entity designated with the Incorporating or Registration Agency a Registered Agent, a Registered Office (as required under the laws of the Jurisdiction of Incorporation or Registration), or an equivalent facility;
+
+3. The entity is not designated on the records of the Incorporating or Registration Agency by labels such as "inactive," "invalid," "not current," or the equivalent;
+
+4. The entity has a verifiable physical existence and business presence;
+
+5. The entity's Jurisdiction of Incorporation, Registration, Charter, or License, and/or its Place of Business is not in any country where the CA is prohibited from doing business or issuing a certificate by the laws of the CA's jurisdiction; and
+
+6. The entity is not listed on any government denial list or prohibited list (e.g., trade embargo) under the laws of the CA's jurisdiction.
+
+#### 4.1.1.2 Government Entity Subjects
+
+An Applicant qualifies as a Government Entity if:
+
+1. The entity's legal existence was established by the political subdivision in which the entity operates;
+
+2. The entity is not in any country where the CA is prohibited from doing business or issuing a certificate by the laws of the CA's jurisdiction; and
+
+3. The entity is not listed on any government denial list or prohibited list (e.g., trade embargo) under the laws of the CA's jurisdiction.
+
+#### 4.1.1.3 Business Entity Subjects
+
+An Applicant qualifies as a Business Entity if:
+
+1. The entity is a legally recognized entity that filed certain forms with a Registration Agency in its jurisdiction, the Registration Agency issued or approved the entity's charter, certificate, or license, and the entity's existence can be verified with that Registration Agency;
+
+2. The entity has a verifiable physical existence and business presence;
+
+3. At least one Principal Individual associated with the entity is identified and validated by the CA;
+
+4. The identified Principal Individual attests to the representations made in the Subscriber Agreement;
+
+5. The CA verifies the entity's use of any assumed name used to represent the entity pursuant to the requirements of [Section 3.2.2.3](#3223-verification-of-applicants-legal-existence-and-identity--assumed-name);
+
+6. The entity and the identified Principal Individual associated with the entity are not located or residing in any country where the CA is prohibited from doing business or issuing a certificate by the laws of the CA's jurisdiction; and
+
+7. The entity and the identified Principal Individual associated with the entity are not listed on any government denial list or prohibited list (e.g., trade embargo) under the laws of the CA's jurisdiction.
+
+#### 4.1.1.4 Non-Commercial Entity Subjects
+
+An Applicant qualifies as a Non-Commercial Entity if:
+
+1. The Applicant is an International Organization Entity, created under a charter, treaty, convention or equivalent instrument that was signed by, or on behalf of, more than one country's government.  The CA/Browser Forum may publish a listing of Applicants who qualify as an International Organization for EV eligibility; and
+
+2. The Applicant is not headquartered in any country where the CA is prohibited from doing business or issuing a certificate by the laws of the CA's jurisdiction; and
+
+3. The Applicant is not listed on any government denial list or prohibited list (e.g., trade embargo) under the laws of the CA's jurisdiction.
+
+Subsidiary organizations or agencies of an entity that qualifies as a Non-Commercial Entity also qualifies for EV Certificates as a Non-Commercial Entity.
+
+### 4.1.2  Enrollment process and responsibilities
+The documentation requirements in Section 4.1.2 of the Baseline Requirements apply equally to EV Certificates.
+The Certificate Request requirements in Section 4.1.2 of the Baseline Requirements apply equally to EV Certificates subject to the additional more stringent ageing and updating requirement of [Section 3.2.2.14](#32214-requirements-for-re-use-of-existing-documentation).
+
+## 4.2 Certificate application processing
+
+### 4.2.1 Performing identification and authentication functions
+The following Applicant roles are required for the issuance of an EV Certificate.
+
+1. **Certificate Requester**: The EV Certificate Request MUST be submitted by an authorized Certificate Requester.  A Certificate Requester is a natural person who is either the Applicant, employed by the Applicant, an authorized agent who has express authority to represent the Applicant, or a third party (such as an ISP or hosting company) that completes and submits an EV Certificate Request on behalf of the Applicant.
+
+2. **Certificate Approver**: The EV Certificate Request MUST be approved by an authorized Certificate Approver.  A Certificate Approver is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant to
+
+   i. act as a Certificate Requester and to authorize other employees or third parties to act as a Certificate Requester, and
+   ii. to approve EV Certificate Requests submitted by other Certificate Requesters.
+
+3. **Contract Signer**: A Subscriber Agreement applicable to the requested EV Certificate MUST be signed by an authorized Contract Signer.  A Contract Signer is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant, and who has authority on behalf of the Applicant to sign Subscriber Agreements.
+
+4. **Applicant Representative**: In the case where the CA and the Subscriber are affiliated, Terms of Use applicable to the requested EV Certificate MUST be acknowledged and agreed to by an authorized Applicant Representative.  An Applicant Representative is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant, and who has authority on behalf of the Applicant to acknowledge and agree to the Terms of Use.
+
+The Applicant MAY authorize one individual to occupy two or more of these roles. The Applicant MAY authorize more than one individual to occupy any of these roles.
+
+### 4.2.2 Approval or rejection of certificate applications
+### 4.2.3  Time to process certificate applications
+
+## 4.3  Certificate issuance
+
+### 4.3.1  CA actions during certificate issuance
 Certificate issuance by the Root CA SHALL require an individual authorized by the CA (i.e. the CA system operator, system officer, or PKI administrator) to deliberately issue a direct command in order for the Root CA to perform a certificate signing operation.
 
 Root CA Private Keys MUST NOT be used to sign EV Certificates.
 
-# 13. Certificate Revocation and Status Checking
+### 4.3.2  Notification to subscriber by the CA of issuance of certificate
 
-The requirements in Section 4.9 of the Baseline Requirements apply equally to EV Certificates.
+## 4.4  Certificate acceptance
+### 4.4.1  Conduct constituting certificate acceptance
+### 4.4.2  Publication of the certificate by the CA
+### 4.4.3  Notification of certificate issuance by the CA to other entities
 
-# 14. Employee and third party issues
+## 4.5 Key pair and certificate usage
+### 4.5.1  Subscriber private key and certificate usage
+### 4.5.2  Relying party public key and certificate usage
 
-## 14.1. Trustworthiness and Competence
+## 4.6  Certificate renewal
+### 4.6.1  Circumstance for certificate renewal
+### 4.6.2  Who may request renewal
+### 4.6.3  Processing certificate renewal requests
+### 4.6.4  Notification of new certificate issuance to subscriber
+### 4.6.5  Conduct constituting acceptance of a renewal certificate
+### 4.6.6  Publication of the renewal certificate by the CA
+### 4.6.7  Notification of certificate issuance by the CA to other entities
 
-### 14.1.1. Identity and Background Verification
+## 4.7  Certificate re-key
+### 4.7.1  Circumstance for certificate re-key
+### 4.7.2  Who may request certification of a new public key
+### 4.7.3  Processing certificate re-keying requests
+### 4.7.4  Notification of new certificate issuance to subscriber
+### 4.7.5  Conduct constituting acceptance of a re-keyed certificate
+### 4.7.6  Publication of the re-keyed certificate by the CA
+### 4.7.7  Notification of certificate issuance by the CA to other entities
 
+## 4.8  Certificate modification
+### 4.8.1  Circumstance for certificate modification
+### 4.8.2  Who may request certificate modification
+### 4.8.3  Processing certificate modification requests
+### 4.8.4  Notification of new certificate issuance to subscriber
+### 4.8.5  Conduct constituting acceptance of modified certificate
+### 4.8.6  Publication of the modified certificate by the CA
+### 4.8.7  Notification of certificate issuance by the CA to other entities
+
+## 4.9  Certificate revocation and suspension
+### 4.9.1  Circumstances for revocation
+### 4.9.2  Who can request revocation
+### 4.9.3  Procedure for revocation request
+### 4.9.4  Revocation request grace period
+### 4.9.5  Time within which CA must process the revocation request
+### 4.9.6  Revocation checking requirement for relying parties
+### 4.9.7 CRL issuance frequency (if applicable)
+### 4.9.8 Maximum latency for CRLs (if applicable)
+### 4.9.9  On-line revocation/status checking availability
+### 4.9.10 On-line revocation checking requirements
+### 4.9.11 Other forms of revocation advertisements available
+### 4.9.12 Special requirements re key compromise
+### 4.9.13 Circumstances for suspension
+### 4.9.14 Who can request suspension
+### 4.9.15 Procedure for suspension request
+### 4.9.16 Limits on suspension period
+
+## 4.10  Certificate status services
+### 4.10.1 Operational characteristics
+### 4.10.2 Service availability
+### 4.10.3 Optional features
+
+## 4.11  End of subscription
+
+## 4.12  Key escrow and recovery
+### 4.12.1 Key escrow and recovery policy and practices
+### 4.12.2 Session key encapsulation and recovery policy and practices
+
+# 5.  FACILITY, MANAGEMENT, AND OPERATIONAL CONTROLS 
+As specified in Section 5 of the Baseline Requirements. In addition, systems used to process and approve EV Certificate Requests MUST require actions by at least two trusted persons before creating an EV Certificate.
+
+## 5.1  Physical controls
+### 5.1.1  Site location and construction
+### 5.1.2  Physical access
+### 5.1.3  Power and air conditioning
+### 5.1.4  Water exposures
+### 5.1.5  Fire prevention and protection
+### 5.1.6  Media storage
+### 5.1.7  Waste disposal
+### 5.1.8  Off-site backup
+
+## 5.2  Procedural controls
+### 5.2.1  Trusted roles
+### 5.2.2  Number of persons required per task
+### 5.2.3  Identification and authentication for each role
+
+### 5.2.4  Roles requiring separation of duties
+1. The CA MUST enforce rigorous control procedures for the separation of validation duties to ensure that no one person can single-handedly validate and authorize the issuance of an EV Certificate.  The Final Cross-Correlation and Due Diligence steps, as outlined in [Section 3.2.2.13](#32213-final-cross-correlation-and-due-diligence), MAY be performed by one of the persons.  For example, one Validation Specialist MAY review and verify all the Applicant information and a second Validation Specialist MAY approve issuance of the EV Certificate.
+2. Such controls MUST be auditable.
+   
+## 5.3  Personnel controls
+
+### 5.3.1  Qualifications, experience, and clearance requirements
+
+### 5.3.2  Background check procedures
 Prior to the commencement of employment of any person by the CA for engagement in the EV Processes, whether as an employee, agent, or an independent contractor of the CA, the CA MUST:
 
 1. **Verify the Identity of Such Person**: Verification of identity MUST be performed through:
@@ -1315,53 +1153,359 @@ Prior to the commencement of employment of any person by the CA for engagement i
 
 3. In the case of employees already in the employ of the CA at the time of adoption of these Guidelines whose identity and background has not previously been verified as set forth above, the CA SHALL conduct such verification within three months of the date of adoption of these Guidelines.
 
-### 14.1.2. Training and Skills Level
-
+### 5.3.3  Training requirements
 The requirements in Section 5.3.3 of the Baseline Requirements apply equally to EV Certificates and these Guidelines.  The required internal examination must relate to the EV Certificate validation criteria outlined in these Guidelines.
 
-### 14.1.3. Separation of Duties
+### 5.3.4  Retraining frequency and requirements
 
-1. The CA MUST enforce rigorous control procedures for the separation of validation duties to ensure that no one person can single-handedly validate and authorize the issuance of an EV Certificate.  The Final Cross-Correlation and Due Diligence steps, as outlined in [Section 11.13](#1113-final-cross-correlation-and-due-diligence), MAY be performed by one of the persons.  For example, one Validation Specialist MAY review and verify all the Applicant information and a second Validation Specialist MAY approve issuance of the EV Certificate.
-2. Such controls MUST be auditable.
+### 5.3.5  Job rotation frequency and sequence
 
-## 14.2. Delegation of Functions to Registration Authorities and Subcontractors
+### 5.3.6  Sanctions for unauthorized actions
 
-### 14.2.1. General
+### 5.3.7  Independent contractor requirements
 
-The CA MAY delegate the performance of all or any part of a requirement of these Guidelines to an Affiliate or a Registration Authority (RA) or subcontractor, provided that the process employed by the CA fulfills all of the requirements of [Section 11.13](#1113-final-cross-correlation-and-due-diligence).
-Affiliates and/or RAs must comply with the qualification requirements of [Section 14.1](#141-trustworthiness-and-competence).
+### 5.3.8  Documentation supplied to personnel
 
-The CA SHALL verify that the Delegated Third Party's personnel involved in the issuance of a Certificate meet the training and skills requirements of [Section 14](#14-employee-and-third-party-issues) and the document retention and event logging requirements of [Section 15](#15-data-records).
-
-### 14.2.2. Enterprise RAs
-
-The CA MAY contractually authorize a Subscriber to perform the RA function and authorize the CA to issue additional EV Certificates.  In such case, the Subscriber SHALL be considered an Enterprise RA, and the following requirements SHALL apply:
-
-1. In all cases, the Subscriber MUST be an organization verified by the CA in accordance with these Guidelines;
-2. The CA MUST impose these limitations as a contractual requirement with the Enterprise RA and monitor compliance by the Enterprise RA; and
-3. The Final Cross-Correlation and Due Diligence requirements of [Section 11.13](#1113-final-cross-correlation-and-due-diligence) MAY be performed by a single person representing the Enterprise RA.
-
-Enterprise RAs that authorize the issuance of EV Certificates solely for its own organization are exempted from the audit requirements of [Section 17.1](#171-eligible-audit-schemes). In all other cases, the requirements of [Section 17.1](#171-eligible-audit-schemes) SHALL apply.
-
-### 14.2.3. Guidelines Compliance Obligation
-
-In all cases, the CA MUST contractually obligate each Affiliate, RA, subcontractor, and Enterprise RA to comply with all applicable requirements in these Guidelines and to perform them as required of the CA itself.  The CA SHALL enforce these obligations and internally audit each Affiliate's, RA's, subcontractor's, and Enterprise RA's compliance with these Requirements on an annual basis.
-
-### 14.2.4. Allocation of Liability
-
-As specified in Section 9.8 of the Baseline Requirements.
-
-# 15. Data Records
-
+## 5.4  Audit logging procedures
 As specified in Section 5.4 of the Baseline Requirements.
 
-# 16. Data Security
+### 5.4.1  Types of events recorded
+### 5.4.2  Frequency of processing log
+### 5.4.3  Retention period for audit log
+### 5.4.4  Protection of audit log
+### 5.4.5  Audit log backup procedures
+### 5.4.6  Audit collection system (internal vs. external)
+### 5.4.7  Notification to event-causing subject
+### 5.4.8  Vulnerability assessments
 
-As specified in Section 5 of the Baseline Requirements. In addition, systems used to process and approve EV Certificate Requests MUST require actions by at least two trusted persons before creating an EV Certificate.
+## 5.5  Records archival
+### 5.5.1  Types of records archived
+### 5.5.2  Retention period for archive
+### 5.5.3  Protection of archive
+### 5.5.4  Archive backup procedures
+### 5.5.5  Requirements for time-stamping of records
+### 5.5.6  Archive collection system (internal or external)
+### 5.5.7  Procedures to obtain and verify archive information
 
-# 17. Audit
+## 5.6  Key changeover
 
-## 17.1. Eligible Audit Schemes
+## 5.7  Compromise and disaster recovery
+### 5.7.1  Incident and compromise handling procedures
+### 5.7.2  Computing resources, software, and/or data are corrupted
+### 5.7.3  Entity private key compromise procedures
+### 5.7.4  Business continuity capabilities after a disaster
+
+## 5.8  CA or RA termination
+
+# 6.  TECHNICAL SECURITY CONTROLS 
+
+## 6.1  Key pair generation and installation
+
+### 6.1.1  Key pair generation
+All requirements in Section 6.1.1.1 of the Baseline Requirements apply equally to EV Certificates. However, for Root CA Key Pairs generated after the release of these Guidelines, the Root CA Key Pair generation ceremony MUST be witnessed by the CA's Qualified Auditor in order to observe the process and the controls over the integrity and confidentiality of the Root CA Key Pairs produced.  The Qualified Auditor MUST then issue a report opining that the CA, during its Root CA Key Pair and Certificate generation process:
+
+  1. Documented its Root CA key generation and protection procedures in its Certificate Policy, and its Certification Practices Statement;
+  2. Included appropriate detail in its Root Key Generation Script;
+  3. Maintained effective controls to provide reasonable assurance that the Root CA key pair was generated and protected in conformity with the procedures described in its CP/CPS and with its Root Key Generation Script;
+  4. Performed, during the Root CA key generation process, all the procedures required by its Root Key Generation Script.
+
+### 6.1.2  Private key delivery to subscriber
+### 6.1.3  Public key delivery to certificate issuer
+### 6.1.4  CA public key delivery to relying parties
+### 6.1.5  Key sizes
+### 6.1.6  Public key parameters generation and quality checking
+### 6.1.7  Key usage purposes (as per X.509 v3 key usage field)
+
+## 6.2  Private Key Protection and Cryptographic Module Engineering Controls
+### 6.2.1  Cryptographic module standards and controls
+### 6.2.2  Private key (n out of m) multi-person control
+### 6.2.3  Private key escrow
+### 6.2.4  Private key backup
+### 6.2.5  Private key archival
+### 6.2.6  Private key transfer into or from a cryptographic module
+### 6.2.7  Private key storage on cryptographic module
+### 6.2.8  Method of activating private key
+### 6.2.9  Method of deactivating private key
+### 6.2.10 Method of destroying private key
+### 6.2.11 Cryptographic Module Rating
+
+## 6.3  Other aspects of key pair management
+### 6.3.1  Public key archival
+
+### 6.3.2  Certificate operational periods and key pair usage periods
+The Validity Period for an EV Certificate SHALL NOT exceed 398 days.
+
+It is RECOMMENDED that EV Subscriber Certificates have a Maximum Validity Period of twelve months.
+
+## 6.4  Activation data
+### 6.4.1  Activation data generation and installation
+### 6.4.2  Activation data protection
+### 6.4.3  Other aspects of activation data
+
+## 6.5  Computer security controls
+### 6.5.1  Specific computer security technical requirements
+### 6.5.2  Computer security rating
+
+## 6.6  Life cycle technical controls
+### 6.6.1  System development controls
+### 6.6.2  Security management controls
+### 6.6.3  Life cycle security controls
+
+## 6.7  Network security controls
+
+## 6.8  Time-stamping
+
+# 7.  CERTIFICATE, CRL, AND OCSP PROFILES
+
+## 7.1  Certificate profile
+This section sets forth minimum requirements for the content of the EV Certificate as they relate to the identity of the CA and the Subject of the EV Certificate.
+
+### 7.1.1  Version number(s)
+
+### 7.1.2  Certificate extensions
+The extensions listed in [Section 7.1.2](#712-certificate-extensions) are recommended for maximum interoperability between certificates and browsers / applications, but are not mandatory on the CAs except where indicated as “Required”.  CAs may use other extensions that are not listed in [Section 7.1.2](#712-certificate-extensions), but are encouraged to add them to this section by ballot from time to time to help increase extension standardization across the industry.
+
+If a CA includes an extension in a certificate that has a Certificate field which is named in [Section 7.1.2](#712-certificate-extensions), the CA must follow the format specified in that subsection.  However, no extension or extension format shall be mandatory on a CA unless specifically stated as “Required” in the subsection that describes the extension.
+
+#### 7.1.2.1 Subject Alternative Name Extension
+
+__Certificate Field__: `subjectAltName:dNSName`  
+__Required/Optional__: __Required__  
+__Contents__: This extension MUST contain one or more host Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service). This extension MUST NOT contain a Wildcard Domain Name unless the FQDN portion of the Wildcard Domain Name is an Onion Domain Name verified in accordance with Appendix B of the Baseline Requirements.
+
+#### 7.1.2.2 CA/Browser Forum Organization Identifier Extension
+
+__Extension Name__: `cabfOrganizationIdentifier` (OID: 2.23.140.3.1)  
+__Verbose OID__: `{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-extensions(3) cabf-organization-identifier(1) }`  
+__Required/Optional__: __Optional (but see below)__  
+__Contents__: If the subject:organizationIdentifier is present, this field MUST be present.
+
+If present, this extension MUST contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme.
+
+The Registration Scheme MUST be encoded as described by the following ASN.1 grammar:
+
+```ASN.1
+id-CABFOrganizationIdentifier OBJECT IDENTIFIER ::= {
+    joint-iso-itu-t(2) international-organizations(23)
+    ca-browser-forum(140) certificate-extensions(3)
+    cabf-organizationIdentifier(1) 
+}
+
+ext-CABFOrganizationIdentifier EXTENSION ::= {
+    SYNTAX CABFOrganizationIdentifier
+    IDENTIFIED BY id-CABFOrganizationIdentifier
+}
+
+CABFOrganizationIdentifier ::= SEQUENCE {
+    registrationSchemeIdentifier PrintableString (SIZE(3)),
+    registrationCountry          PrintableString (SIZE(2)),
+    registrationStateOrProvince  [0] IMPLICIT PrintableString
+                                  (SIZE(0..128)) OPTIONAL,
+    registrationReference        UTF8String
+}
+```
+
+where the subfields have the same values, meanings, and restrictions described in [Section 7.1.4.2.8](#71428-subject-organization-identifier-field). The CA SHALL validate the contents using the requirements in [Section 7.1.4.2.8](#71428-subject-organization-identifier-field).
+
+### 7.1.3  Algorithm object identifiers
+### 7.1.4  Name forms
+#### 7.1.4.1 Issuer Information
+
+Issuer Information listed in an EV Certificate MUST comply with Section 7.1.4.1 of the Baseline Requirements.
+
+#### 7.1.4.2 Subject Distinguished Name Fields
+
+Subject to the requirements of these Guidelines, the EV Certificate and certificates issued to Subordinate CAs that are not controlled by the same entity as the CA MUST include the following information about the Subject organization in the fields listed:
+
+##### 7.1.4.2.1 Subject Organization Name Field
+
+__Certificate Field__: `subject:organizationName` (OID 2.5.4.10)  
+__Required/Optional__: Required  
+__Contents__: This field MUST contain the Subject's full legal organization name as listed in the official records of the Incorporating or Registration Agency in the Subject's Jurisdiction of Incorporation or Registration or as otherwise verified by the CA as provided herein. A CA MAY abbreviate the organization prefixes or suffixes in the organization name, e.g., if the official record shows "Company Name Incorporated" the CA MAY include "Company Name, Inc."
+
+When abbreviating a Subject's full legal name as allowed by this subsection, the CA MUST use abbreviations that are not misleading in the Jurisdiction of Incorporation or Registration.
+
+In addition, an assumed name or DBA name used by the Subject MAY be included at the beginning of this field, provided that it is followed by the full legal organization name in parenthesis.
+
+If the combination of names or the organization name by itself exceeds 64 characters, the CA MAY abbreviate parts of the organization name, and/or omit non-material words in the organization name in such a way that the text in this field does not exceed the 64-character limit; provided that the CA checks this field in accordance with [Section 3.2.2.12.1](#322121-high-risk-status) and a Relying Party will not be misled into thinking that they are dealing with a different organization. In cases where this is not possible, the CA MUST NOT issue the EV Certificate.
+
+##### 7.1.4.2.2 Subject Common Name Field
+
+__Certificate Field__: `subject:commonName` (OID: 2.5.4.3)  
+__Required/Optional__: Deprecated (Discouraged, but not prohibited)  
+__Contents__: If present, this field MUST contain a single Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service). This field MUST NOT contain a Wildcard Domain Name unless the FQDN portion of the Wildcard Domain Name is an Onion Domain Name verified in accordance with Appendix B of the Baseline Requirements.
+
+##### 7.1.4.2.3 Subject Business Category Field
+
+__Certificate Field__: `subject:businessCategory` (OID: 2.5.4.15)  
+__Required/Optional__: Required  
+__Contents__: This field MUST contain one of the following strings: "Private Organization", "Government Entity", "Business Entity", or "Non-Commercial Entity" depending upon whether the Subject qualifies under the terms of [Section 4.1.1.1](#4111-private-organization-subjects), [Section 4.1.1.2](#4112-government-entity-subjects), [Section 4.1.1.3](#4113-business-entity-subjects) or [Section 4.1.1.4](#4114-non-commercial-entity-subjects), respectively.
+
+##### 7.1.4.2.4 Subject Jurisdiction of Incorporation or Registration Field
+
+__Certificate Fields__:
+
+Locality (if required):  
+  `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1)
+
+State or province (if required):  
+  `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2)
+
+Country:  
+  `subject:jurisdictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3)
+
+__Required/Optional__: Required  
+__Contents__: These fields MUST NOT contain information that is not relevant to the level of the Incorporating Agency or Registration Agency.  For example, the Jurisdiction of Incorporation for an Incorporating Agency or Jurisdiction of Registration for a Registration Agency that operates at the country level MUST include the country information but MUST NOT include the state or province or locality information.  Similarly, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the state or province level MUST include both country and state or province information, but MUST NOT include locality information.  And, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the locality level MUST include the country and state or province information, where the state or province regulates the registration of the entities at the locality level, as well as the locality information.  Country information MUST be specified using the applicable ISO country code.  State or province or locality information (where applicable) for the Subject's Jurisdiction of Incorporation or Registration MUST be specified using the full name of the applicable jurisdiction.
+
+Effective as of 1 October 2020, the CA SHALL ensure that, at time of issuance, the values within these fields have been disclosed within the latest publicly-available disclosure, as described in [Section 3.2.2.1.3](#32213-disclosure-of-verification-sources), as acceptable values for the applicable Incorporating Agency or Registration Agency.
+
+##### 7.1.4.2.5 Subject Registration Number Field
+
+__Certificate Field__: `subject:serialNumber` (OID: 2.5.4.5)  
+__Required/Optional__: __Required__  
+__Contents__: For Private Organizations, this field MUST contain the Registration (or similar) Number assigned to the Subject by the Incorporating or Registration Agency in its Jurisdiction of Incorporation or Registration, as appropriate.  If the Jurisdiction of Incorporation or Registration does not provide a Registration Number, then the date of Incorporation or Registration SHALL be entered into this field in any one of the common date formats.
+
+For Government Entities that do not have a Registration Number or readily verifiable date of creation, the CA SHALL enter appropriate language to indicate that the Subject is a Government Entity.
+
+For Business Entities, the Registration Number that was received by the Business Entity upon government registration SHALL be entered in this field.  For those Business Entities that register with an Incorporating Agency or Registration Agency in a jurisdiction that does not issue numbers pursuant to government registration, the date of the registration SHALL be entered into this field in any one of the common date formats.
+
+Effective as of 1 October 2020, if the CA has disclosed a set of acceptable format or formats for Registration Numbers for the applicable Registration Agency or Incorporating Agency, as described in [Section 3.2.2.1.3](#32213-disclosure-of-verification-sources), the CA MUST ensure, prior to issuance, that the Registration Number is valid according to at least one currently disclosed format for that applicable Registration Agency or Incorporating agency.
+
+##### 7.1.4.2.6 Subject Physical Address of Place of Business Field
+
+__Certificate Fields__:  
+    Number and street: `subject:streetAddress` (OID: 2.5.4.9)  
+    City or town: `subject:localityName` (OID: 2.5.4.7)  
+    State or province (where applicable): `subject:stateOrProvinceName` (OID: 2.5.4.8)  
+    Country: `subject:countryName` (OID: 2.5.4.6)  
+    Postal code: `subject:postalCode` (OID: 2.5.4.17)  
+__Required/Optional__: As stated in Section 7.1.4.2.2 d, e, f, g and h of the Baseline Requirements.  
+__Contents__: This field MUST contain the address of the physical location of the Subject's Place of Business.
+
+##### 7.1.4.2.7 Subject Organizational Unit Name Field
+
+__Certificate Field__: `subject:organizationalUnitName` (OID: 2.5.4.11)  
+__Required/Optional/Prohibited:__ __Prohibited__. 
+
+##### 7.1.4.2.8 Subject Organization Identifier Field
+
+__Certificate Field__: `subject:organizationIdentifier` (OID: 2.5.4.97)  
+__Required/Optional__: Optional  
+__Contents__: If present, this field MUST contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme.
+
+The organizationIdentifier MUST be encoded as a PrintableString or UTF8String.
+
+The Registration Scheme MUST be identified using the using the following structure in the presented order:
+
+* 3 character Registration Scheme identifier;
+* 2 character ISO 3166 country code for the nation in which the Registration Scheme is operated, or if the scheme is operated globally ISO 3166 code "XG" shall be used;
+* For the NTR Registration Scheme identifier, if required under [Section 7.1.4.2.4](#71424-subject-jurisdiction-of-incorporation-or-registration-field), a 2 character ISO 3166-2 identifier for the subdivision (state or province) of the nation in which the Registration Scheme is operated, preceded by plus "+" (0x2B (ASCII), U+002B (UTF-8));
+* a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8));
+* Registration Reference allocated in accordance with the identified Registration Scheme
+
+Note: Registration References MAY contain hyphens, but Registration Schemes, ISO 3166 country codes, and ISO 3166-2 identifiers do not.  Therefore if more than one hyphen appears in the structure, the leftmost hyphen is a separator, and the remaining hyphens are part of the Registration Reference.
+
+As in [Section 7.1.4.2.4](#71424-subject-jurisdiction-of-incorporation-or-registration-field), the specified location information MUST match the scope of the registration being referenced.
+
+Examples:
+
+* `NTRGB-12345678` (NTR scheme, Great Britain, Unique Identifier at Country level is 12345678)
+* `NTRUS+CA-12345678` (NTR Scheme, United States - California, Unique identifier at State level is 12345678)
+* `VATDE-123456789` (VAT Scheme, Germany, Unique Identifier at Country Level is 12345678)
+* `PSDBE-NBB-1234.567.890` (PSD Scheme, Belgium, NCA's identifier is NBB, Subject Unique Identifier assigned by the NCA is 1234.567.890)
+
+Registration Schemes listed in [Appendix H](#appendix-h--registration-schemes) are currently recognized as valid under these guidelines.
+
+The CA SHALL:
+
+1. confirm that the organization represented by the Registration Reference is the same as the organization named in the `organizationName` field as specified in [Section 7.1.4.2.1](#71421-subject-organization-name-field) within the context of the subject’s jurisdiction as specified in [Section 7.1.4.2.4](#71424-subject-jurisdiction-of-incorporation-or-registration-field);
+2. further verify the Registration Reference matches other information verified in accordance with [Section 3.2](#32-initial-identity-validation);
+3. take appropriate measures to disambiguate between different organizations as described in [Appendix H](#appendix-h--registration-schemes) for each Registration Scheme;
+4. Apply the validation rules relevant to the Registration Scheme as specified in [Appendix H](#appendix-h--registration-schemes).
+
+##### 7.1.4.2.9 Other Subject Attributes
+
+CAs SHALL NOT include any Subject Distinguished Name attributes except as specified in [Section 7.1.4.2](#7142-subject-distinguished-name-fields).
+
+#### 7.1.4.3 Additional Technical Requirements for EV Certificates
+
+All provisions of the Baseline Requirements concerning Minimum Cryptographic Algorithms, Key Sizes, and Certificate Extensions apply to EV Certificates with the following exceptions:
+
+1. If a Subordinate CA Certificates is issued to a Subordinate CA not controlled by the entity that controls the Root CA, the policy identifiers in the `certificatePolicies` extension MUST include the CA's Extended Validation policy identifier.
+
+   Otherwise, it MAY contain the anyPolicy identifier.
+
+2. The following fields MUST be present if the Subordinate CA is not controlled by the entity that controls the Root CA.
+
+   * `certificatePolicies:policyQualifiers:policyQualifierId`
+
+      `id-qt 1` [RFC 5280]
+
+   * `certificatePolicies:policyQualifiers:qualifier:cPSuri`
+
+      HTTP URL for the Root CA's Certification Practice Statement
+
+3. The `certificatePolicies` extension in EV Certificates issued to Subscribers MUST include the following:
+
+   * `certificatePolicies:policyIdentifier` (Required)
+
+      The Issuer's EV policy identifier
+
+   * `certificatePolicies:policyQualifiers:policyQualifierId` (Required)
+
+      `id-qt 1` [RFC 5280]
+
+   * `certificatePolicies:policyQualifiers:qualifier:cPSuri` (Required)
+
+      HTTP URL for the Subordinate CA's Certification Practice Statement
+
+4. The `cRLDistributionPoints` extension MUST be present in Subscriber Certificates if the certificate does not specify OCSP responder locations in an `authorityInformationAccess` extension.
+
+
+### 7.1.5  Name constraints
+
+### 7.1.6  Certificate policy object identifier
+This section sets forth minimum requirements for the contents of EV Certificates as they relate to the identification of EV Certificate Policy.
+
+#### 7.1.6.1 EV Subscriber Certificates
+
+Each EV Certificate issued by the CA to a Subscriber MUST contain a policy identifier that is either defined by these Guidelines or the CA in the certificate's `certificatePolicies` extension that:
+
+1. indicates which CA policy statement relates to that Certificate,
+2. asserts the CA's adherence to and compliance with these Guidelines, and
+3. is either the CA/Browser Forum’s EV policy identifier or a policy identifier that, by pre-agreement with the Application Software Supplier, marks the Certificate as being an EV Certificate.
+
+The following Certificate Policy identifier is the CA/Browser Forum’s EV policy identifier:
+`{joint‐iso‐itu‐t(2) international‐organizations(23) ca‐browser‐forum(140) certificate‐policies(1) ev-guidelines (1) } (2.23.140.1.1)`, if the Certificate complies with these Guidelines.
+
+#### 7.1.6.2 Root CA Certificates
+
+The Application Software Supplier identifies Root CAs that are approved to issue EV Certificates by storing EV policy identifiers in metadata associated with Root CA Certificates.
+
+#### 7.1.6.3 EV Subordinate CA Certificates
+
+1. Certificates issued to Subordinate CAs that are not controlled by the issuing CA MUST contain one or more policy identifiers defined by the issuing CA that explicitly identify the EV Policies that are implemented by the Subordinate CA.
+2. Certificates issued to Subordinate CAs that are controlled by the Root CA MAY contain the special `anyPolicy` identifier (OID: 2.5.29.32.0).
+
+#### 7.1.6.4 Subscriber Certificates
+
+A Certificate issued to a Subscriber MUST contain one or more policy identifier(s), defined by the Issuing CA, in the Certificate's `certificatePolicies` extension that indicates adherence to and compliance with these Guidelines.  Each CA SHALL document in its Certificate Policy or Certification Practice Statement that the Certificates it issues containing the specified policy identifier(s) are managed in accordance with these Guidelines.
+
+### 7.1.7  Usage of Policy Constraints extension
+
+### 7.1.8  Policy qualifiers syntax and semantics
+
+### 7.1.9 Processing semantics for the critical Certificate Policies extension
+
+## 7.2  CRL profile
+### 7.2.1  Version number(s)
+### 7.2.2  CRL and CRL entry extensions
+
+## 7.3  OCSP profile
+### 7.3.1  Version number(s)
+### 7.3.2  OCSP extensions
+
+# 8.  COMPLIANCE AUDIT AND OTHER ASSESSMENTS
 
 A CA issuing EV Certificates SHALL undergo an audit in accordance with one of the following schemes:
 
@@ -1371,17 +1515,23 @@ iii. ETSI EN 319 411-1 audit for EVCP policy.
 
 If the CA is a Government Entity, an audit of the CA by the appropriate internal government auditing agency is acceptable in lieu of the audits specified above, provided that such internal government auditing agency publicly certifies in writing that its audit addresses the criteria specified in one of the above audit schemes and certifies that the government CA has successfully passed the audit.
 
-EV audits MUST cover all CA obligations under these Guidelines regardless of whether they are performed directly by the CA or delegated to an RA or subcontractor.
+## 8.1  Frequency or circumstances of assessment
+CAs issuing EV Certificates MUST undergo an annual audit that meets the criteria of [Section 8](#8-compliance-audit-and-other-assessments).
 
-## 17.2. Audit Period
+### 8.1.1  Self audits
+During the period in which it issues EV Certificates, the CA MUST strictly control its service quality by performing ongoing self audits against a randomly selected sample of at least three percent of the EV Certificates it has issued in the period beginning immediately after the last sample was taken.  For all EV Certificates where the Final Cross-Correlation and Due Diligence requirements of [Section 3.2.2.13](#32213-final-cross-correlation-and-due-diligence) is performed by an RA, the CA MUST strictly control its service quality by performing ongoing self audits against a randomly selected sample of at least six percent of the EV Certificates it has issued in the period beginning immediately after the last sample was taken.
 
-CAs issuing EV Certificates MUST undergo an annual audit that meets the criteria of [Section 17.1](#171-eligible-audit-schemes).
+## 8.2  Identity/qualifications of assessor
+A Qualified Auditor (as defined in Section 8.2 of the Baseline Requirements) MUST perform the CA's audit.
 
-## 17.3  Audit Record
+## 8.3  Assessor's relationship to assessed entity
+## 8.4  Topics covered by assessment
+## 8.5  Actions taken as a result of deficiency
 
+## 8.6  Communication of results
 CAs SHOULD make its audit report publicly available no later than three months after the end of the audit period.  If there is a delay greater than three months and if so requested by an Application Software Supplier, the CA MUST provide an explanatory letter signed by its auditor.
 
-## 17.4. Pre-Issuance Readiness Audit
+## 8.7  Pre-issuance Readiness Audit
 
 1. If the CA has a currently valid WebTrust Seal of Assurance for CAs, then, before issuing EV Certificates, the CA and its Root CA MUST successfully complete a point-in-time readiness assessment audit against the WebTrust EV Program.
 2. If the CA has a currently valid ETSI 102 042 audit, then, before issuing EV Certificates, the CA and its Root CA MUST successfully complete a point-in-time readiness assessment audit against ETSI TS 102 042.
@@ -1392,31 +1542,107 @@ CAs SHOULD make its audit report publicly available no later than three months a
 
 The CA MUST complete any required point-in-time readiness assessment no earlier than twelve (12) months prior to issuing an EV Certificate.  The CA MUST undergo a complete audit under such scheme within ninety (90) days of issuing the first EV Certificate.
 
-## 17.5. Regular Self Audits
+# 9.  OTHER BUSINESS AND LEGAL MATTERS
+## 9.1  Fees
+### 9.1.1  Certificate issuance or renewal fees
+### 9.1.2  Certificate access fees
+### 9.1.3  Revocation or status information access fees
+### 9.1.4  Fees for other services
+### 9.1.5  Refund policy
 
-During the period in which it issues EV Certificates, the CA MUST strictly control its service quality by performing ongoing self audits against a randomly selected sample of at least three percent of the EV Certificates it has issued in the period beginning immediately after the last sample was taken.  For all EV Certificates where the Final Cross-Correlation and Due Diligence requirements of [Section 11.13](#1113-final-cross-correlation-and-due-diligence) is performed by an RA, the CA MUST strictly control its service quality by performing ongoing self audits against a randomly selected sample of at least six percent of the EV Certificates it has issued in the period beginning immediately after the last sample was taken.
+## 9.2  Financial responsibility
 
-## 17.6. Auditor Qualification
+### 9.2.1  Insurance coverage
+Each CA SHALL maintain the following insurance related to their respective performance and obligations under these Guidelines:
 
-A Qualified Auditor (as defined in Section 8.2 of the Baseline Requirements) MUST perform the CA's audit.
+A.  Commercial General Liability insurance (occurrence form) with policy limits of at least two million US dollars in coverage; and
 
-## 17.7. Root CA Key Pair Generation
+B.  Professional Liability/Errors and Omissions insurance, with policy limits of at least five million US dollars in coverage, and including coverage for:
+    i. claims for damages arising out of an act, error, or omission, unintentional breach of contract, or neglect in issuing or maintaining EV Certificates, and;
+    ii. claims for damages arising out of infringement of the proprietary rights of any third party (excluding copyright, and trademark infringement), and invasion of privacy and advertising injury.
 
-All requirements in Section 6.1.1.1 of the Baseline Requirements apply equally to EV Certificates. However, for Root CA Key Pairs generated after the release of these Guidelines, the Root CA Key Pair generation ceremony MUST be witnessed by the CA's Qualified Auditor in order to observe the process and the controls over the integrity and confidentiality of the Root CA Key Pairs produced.  The Qualified Auditor MUST then issue a report opining that the CA, during its Root CA Key Pair and Certificate generation process:
+Such insurance must be with a company rated no less than A- as to Policy Holder's Rating in the current edition of Best's Insurance Guide (or with an association of companies each of the members of which are so rated).
 
-  1. Documented its Root CA key generation and protection procedures in its Certificate Policy, and its Certification Practices Statement;
-  2. Included appropriate detail in its Root Key Generation Script;
-  3. Maintained effective controls to provide reasonable assurance that the Root CA key pair was generated and protected in conformity with the procedures described in its CP/CPS and with its Root Key Generation Script;
-  4. Performed, during the Root CA key generation process, all the procedures required by its Root Key Generation Script.
+A CA MAY self-insure for liabilities that arise from such party's performance and obligations under these Guidelines provided that it has at least five hundred million US dollars in liquid assets based on audited financial statements in the past twelve months, and a quick ratio (ratio of liquid assets to current liabilities) of not less than 1.0.
 
-# 18. Liability and Indemnification
+### 9.2.2  Other assets
+### 9.2.3  Insurance or warranty coverage for end-entities
+## 9.3  Confidentiality of business information
+### 9.3.1  Scope of confidential information
+### 9.3.2  Information not within the scope of confidential information
+### 9.3.3  Responsibility to protect confidential information
+## 9.4  Privacy of personal information
+### 9.4.1  Privacy plan
+### 9.4.2  Information treated as private
+### 9.4.3  Information not deemed private
+### 9.4.4  Responsibility to protect private information
+### 9.4.5  Notice and consent to use private information
+### 9.4.6 Disclosure pursuant to judicial or administrative process
+### 9.4.7  Other information disclosure circumstances
+## 9.5  Intellectual property rights
+## 9.6  Representations and warranties
 
+### 9.6.1  CA representations and warranties
+When the CA issues an EV Certificate, the CA and its Root CA represent and warrant to the Certificate Beneficiaries listed in Section 9.6.1 of the Baseline Requirements, during the period when the EV Certificate is Valid, that the CA has followed the requirements of these Guidelines and its EV Policies in issuing and managing the EV Certificate and in verifying the accuracy of the information contained in the EV Certificate.  The EV Certificate Warranties specifically include, but are not limited to, the following:
+
+A.  **Legal Existence**: The CA has confirmed with the Incorporating or Registration Agency in the Subject's Jurisdiction of Incorporation or Registration that, as of the date the EV Certificate was issued, the Subject named in the EV Certificate legally exists as a valid organization or entity in the Jurisdiction of Incorporation or Registration;
+
+B.  **Identity**: The CA has confirmed that, as of the date the EV Certificate was issued, the legal name of the Subject named in the EV Certificate matches the name on the official government records of the Incorporating or Registration Agency in the Subject's Jurisdiction of Incorporation or Registration, and if an assumed name is also included, that the assumed name is properly registered by the Subject in the jurisdiction of its Place of Business;
+
+C.  **Right to Use Domain Name**: The CA has taken all steps reasonably necessary to verify that, as of the date the EV Certificate was issued, the Subject named in the EV Certificate has the right to use all the Domain Name(s) listed in the EV Certificate;
+
+D.  **Authorization for EV Certificate**: The CA has taken all steps reasonably necessary to verify that the Subject named in the EV Certificate has authorized the issuance of the EV Certificate;
+
+E.  **Accuracy of Information**: The CA has taken all steps reasonably necessary to verify that all of the other information in the EV Certificate is accurate, as of the date the EV Certificate was issued;
+
+F.  **Subscriber Agreement**: The Subject named in the EV Certificate has entered into a legally valid and enforceable Subscriber Agreement with the CA that satisfies the requirements of these Guidelines or, if they are affiliated, the Applicant Representative has acknowledged and accepted the Terms of Use;
+
+G.  **Status**: The CA will follow the requirements of these Guidelines and maintain a 24 x 7 online-accessible Repository with current information regarding the status of the EV Certificate as Valid or revoked; and
+
+H.  **Revocation**: The CA will follow the requirements of these Guidelines and revoke the EV Certificate for any of the revocation reasons specified in these Guidelines.
+
+### 9.6.2  RA representations and warranties
+
+### 9.6.3  Subscriber representations and warranties
+Section 9.6.3 of the Baseline Requirements applies equally to EV Certificates.  In cases where the Certificate Request does not contain all necessary information about the Applicant, the CA MUST additionally confirm the data with the Certificate Approver or Contract Signer rather than the Certificate Requester.
+
+EV Certificate Applicants make the commitments and warranties set forth in Section 9.6.3 of the Baseline Requirements for the benefit of the CA and Certificate Beneficiaries.
+### 9.6.4  Relying party representations and warranties
+### 9.6.5  Representations and warranties of other participants
+## 9.7  Disclaimers of warranties
+
+## 9.8  Limitations of liability
 CAs MAY limit their liability as described in Section 9.8 of the Baseline Requirements except that a CA MUST NOT limit its liability to Subscribers or Relying Parties for legally recognized and provable claims to a monetary amount less than two thousand US dollars per Subscriber or Relying Party per EV Certificate.
 
+## 9.9  Indemnities
 A CA's indemnification obligations and a Root CA's obligations with respect to subordinate CAs are set forth in Section 9.9 of the Baseline Requirements.
 
-# Appendix A - User Agent Verification (Normative)
+## 9.10  Term and termination
+### 9.10.1  Term
+### 9.10.2  Termination
+### 9.10.3  Effect of termination and survival
+## 9.11  Individual notices and communications with participants
+## 9.12  Amendments
+### 9.12.1  Procedure for amendment
+### 9.12.2  Notification mechanism and period
+### 9.12.3  Circumstances under which OID must be changed
+## 9.13  Dispute resolution provisions
+## 9.14  Governing law
+## 9.15  Compliance with applicable law
+## 9.16  Miscellaneous provisions
+### 9.16.1  Entire agreement
+### 9.16.2  Assignment
 
+### 9.16.3  Severability
+The CA MAY issue EV Certificates, provided that the CA and its Root CA satisfy the requirements in these Guidelines and the Baseline Requirements.
+
+If a court or government body with jurisdiction over the activities covered by these Guidelines determines that the performance of any mandatory requirement is illegal, then such requirement is considered reformed to the minimum extent necessary to make the requirement valid and legal.  This applies only to operations or certificate issuances that are subject to the laws of that jurisdiction.  The parties involved SHALL notify the CA/Browser Forum of the facts, circumstances, and law(s) involved, so that the CA/Browser Forum may revise these Guidelines accordingly.
+
+### 9.16.4  Enforcement (attorneys' fees and waiver of rights)
+### 9.16.5  Force Majeure
+## 9.17  Other provisions
+
+# Appendix A - User Agent Verification (Normative)
 The CA MUST host test Web pages that allow Application Software Suppliers to test their software with EV Certificates that chain up to each EV Root Certificate.  At a minimum, the CA MUST host separate Web pages using certificates that are:
 
   i. valid;
@@ -1697,12 +1923,55 @@ The following Registration Schemes are currently recognized as valid under these
 
 * **NTR**:
 
-  The information carried in this field shall be the same as held in Subject Registration Number Field as specified in [Section 9.2.5](#925-subject-registration-number-field) and the country code used in the Registration Scheme identifier shall match that of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). Where the Subject Jurisdiction of Incorporation or Registration Field in 9.2.4 includes more than the country code, the additional locality information shall be included as specified in [Section 9.2.8](#928-subject-organization-identifier-field) and/or [Section 9.8.2](#982-cabrowser-forum-organization-identifier-extension).
+  The information carried in this field shall be the same as held in
+  Subject Registration Number Field as specified in
+  [Section 7.1.4.2.5](#71425-subject-registration-number-field) and the country code
+  used in the Registration Scheme identifier shall match that of the
+  subject’s jurisdiction as specified in
+  [Section 7.1.4.2.4](#71424-subject-jurisdiction-of-incorporation-or-registration-field).
+
+  Where the Subject Jurisdiction of Incorporation or Registration Field in 9.2.4
+  includes more than the country code, the additional locality information shall
+  be included as specified in [Section 7.1.4.2.8](#71428-subject-organization-identifier-field)
+  and/or [Section 7.1.2.2](#7122-cabrowser-forum-organization-identifier-extension).
 
 * **VAT**:
 
-  Reference allocated by the national tax authorities to a Legal Entity. This information shall be validated using information provided by the national tax authority against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). For the purpose of identifying tax authorities, the country prefix described in article 215 of EU Council Directive 2006/112/EC, as amended, MAY be used instead of the ISO 3166 2-letter country codes.
+  Reference allocated by the national tax authorities to a Legal Entity. This
+  information shall be validated using information provided by the national tax
+  authority against the organization as identified by the Subject Organization
+  Name Field (see [Section 7.1.4.2.1](#71421-subject-organization-name-field)) and
+  Subject Registration Number Field (see
+  Section 7.1.4.2.5](#71425-subject-registration-number-field)) within the context of
+  the subject’s jurisdiction as specified in
+  [Section 7.1.4.2.4](#71424-subject-jurisdiction-of-incorporation-or-registration-field).
+  For the purpose of identifying tax authorities, the country prefix described in article 215 of 
+  EU Council Directive 2006/112/EC, as amended, MAY be used instead of the ISO 3166 2-letter country codes.
 
-* **PSD**:
+  * **PSD**:
 
-  Authorization number as specified in ETSI TS 119 495 clause 4.4 allocated to a payment service provider and containing the information as specified in ETSI TS 119 495 clause 5.2.1. This information SHALL be obtained directly from the national competent authority register for payment services or from an information source approved by a government agency, regulatory body, or legislation for this purpose. This information SHALL be validated by being matched directly or indirectly (for example, by matching a globally unique registration number) against the organization as identified by the Subject Organization Name Field (see [Section 9.2.1](#921-subject-organization-name-field)) and Subject Registration Number Field (see [Section 9.2.5](#925-subject-registration-number-field)) within the context of the subject’s jurisdiction as specified in [Section 9.2.4](#924-subject-jurisdiction-of-incorporation-or-registration-field). The stated address of the organization combined with the organization name SHALL NOT be the only information used to disambiguate the organization.
+  Authorization number as specified in ETSI TS 119 495 clause 4.4
+  allocated to a payment service provider and containing the information as
+  specified in ETSI TS 119 495 clause 5.2.1.  This information SHALL be
+  obtained directly from the national competent authority register for
+  payment services or from an information source approved by a government
+  agency, regulatory body, or legislation for this purpose.  This information
+  SHALL be validated by being matched directly or indirectly (for example, by
+  matching a globally unique registration number) against the organization as
+  identified by the Subject Organization Name Field (see
+  [Section 7.1.4.2.1](#71421-subject-organization-name-field)) and
+  Subject Registration Number Field (see
+  [Section 7.1.4.2.5](#71425-subject-registration-number-field)) within the context of
+  the subject’s jurisdiction as specified in
+  [Section 7.1.4.2.4](#71424-subject-jurisdiction-of-incorporation-or-registration-field).
+  The stated address of the organization combined with the organization name
+  SHALL NOT be the only information used to disambiguate the organization.
+  
+
+
+
+
+
+  
+
+

--- a/docs/RFC3647_Template.md
+++ b/docs/RFC3647_Template.md
@@ -1,0 +1,270 @@
+# 1.  INTRODUCTION
+## 1.1  Overview
+## 1.2  Document name and identification
+## 1.3  PKI participants
+### 1.3.1  Certification authorities
+### 1.3.2  Registration authorities
+### 1.3.3  Subscribers
+### 1.3.4 Relying parties
+### 1.3.5  Other participants
+## 1.4  Certificate usage
+### 1.4.1  Appropriate certificate uses
+### 1.4.2 Prohibited certificate uses
+## 1.5  Policy administration
+### 1.5.1  Organization administering the document
+### 1.5.2  Contact person
+### 1.5.3  Person determining CPS suitability for the policy
+### 1.5.4  CPS approval procedures
+## 1.6  Definitions and acronyms
+# 2. PUBLICATION AND REPOSITORY RESPONSIBILITIES
+## 2.1  Repositories
+## 2.2  Publication of certification information
+## 2.3  Time or frequency of publication
+## 2.4  Access controls on repositories
+# 3. IDENTIFICATION AND AUTHENTICATION (11)
+## 3.1  Naming
+### 3.1.1  Types of names
+### 3.1.2  Need for names to be meaningful
+### 3.1.3  Anonymity or pseudonymity of subscribers
+### 3.1.4  Rules for interpreting various name forms
+### 3.1.5  Uniqueness of names
+### 3.1.6  Recognition, authentication, and role of trademarks
+## 3.2  Initial identity validation
+### 3.2.1  Method to prove possession of private key
+### 3.2.2  Authentication of organization identity
+### 3.2.3  Authentication of individual identity
+### 3.2.4  Non-verified subscriber information
+### 3.2.5 Validation of authority
+### 3.2.6  Criteria for interoperation
+## 3.3  Identification and authentication for re-key requests
+### 3.3.1  Identification and authentication for routine re-key
+### 3.3.2  Identification and authentication for re-key after revocation
+## 3.4 Identification and authentication for revocation request
+# 4.  CERTIFICATE LIFE-CYCLE OPERATIONAL REQUIREMENTS
+## 4.1  Certificate Application
+### 4.1.1  Who can submit a certificate application
+### 4.1.2  Enrollment process and responsibilities
+## 4.2 Certificate application processing
+### 4.2.1 Performing identification and authentication functions
+### 4.2.2 Approval or rejection of certificate applications
+### 4.2.3  Time to process certificate applications
+## 4.3  Certificate issuance
+### 4.3.1  CA actions during certificate issuance
+### 4.3.2  Notification to subscriber by the CA of issuance of certificate
+## 4.4  Certificate acceptance
+### 4.4.1  Conduct constituting certificate acceptance
+### 4.4.2  Publication of the certificate by the CA
+### 4.4.3  Notification of certificate issuance by the CA to other entities
+## 4.5 Key pair and certificate usage
+### 4.5.1  Subscriber private key and certificate usage
+### 4.5.2  Relying party public key and certificate usage
+## 4.6  Certificate renewal
+### 4.6.1  Circumstance for certificate renewal
+### 4.6.2  Who may request renewal
+### 4.6.3  Processing certificate renewal requests
+### 4.6.4  Notification of new certificate issuance to subscriber
+### 4.6.5  Conduct constituting acceptance of a renewal certificate
+### 4.6.6  Publication of the renewal certificate by the CA
+### 4.6.7  Notification of certificate issuance by the CA to other entities
+## 4.7  Certificate re-key
+### 4.7.1  Circumstance for certificate re-key
+### 4.7.2  Who may request certification of a new public key
+### 4.7.3  Processing certificate re-keying requests
+### 4.7.4  Notification of new certificate issuance to subscriber
+### 4.7.5  Conduct constituting acceptance of a re-keyed certificate
+### 4.7.6  Publication of the re-keyed certificate by the CA
+### 4.7.7  Notification of certificate issuance by the CA to other entities
+## 4.8  Certificate modification
+### 4.8.1  Circumstance for certificate modification
+### 4.8.2  Who may request certificate modification
+### 4.8.3  Processing certificate modification requests
+### 4.8.4  Notification of new certificate issuance to subscriber
+### 4.8.5  Conduct constituting acceptance of modified certificate
+### 4.8.6  Publication of the modified certificate by the CA
+### 4.8.7  Notification of certificate issuance by the CA to other entities
+## 4.9  Certificate revocation and suspension
+### 4.9.1  Circumstances for revocation
+### 4.9.2  Who can request revocation
+### 4.9.3  Procedure for revocation request
+### 4.9.4  Revocation request grace period
+### 4.9.5  Time within which CA must process the revocation request
+### 4.9.6  Revocation checking requirement for relying parties
+### 4.9.7 CRL issuance frequency (if applicable)
+### 4.9.8 Maximum latency for CRLs (if applicable)
+### 4.9.9  On-line revocation/status checking availability
+### 4.9.10 On-line revocation checking requirements
+### 4.9.11 Other forms of revocation advertisements available
+### 4.9.12 Special requirements re key compromise
+### 4.9.13 Circumstances for suspension
+### 4.9.14 Who can request suspension
+### 4.9.15 Procedure for suspension request
+### 4.9.16 Limits on suspension period
+## 4.10  Certificate status services
+### 4.10.1 Operational characteristics
+### 4.10.2 Service availability
+### 4.10.3 Optional features
+## 4.11  End of subscription
+## 4.12  Key escrow and recovery
+### 4.12.1 Key escrow and recovery policy and practices
+### 4.12.2 Session key encapsulation and recovery policy and practices
+# 5.  FACILITY, MANAGEMENT, AND OPERATIONAL CONTROLS (11)
+## 5.1  Physical controls
+### 5.1.1  Site location and construction
+### 5.1.2  Physical access
+### 5.1.3  Power and air conditioning
+### 5.1.4  Water exposures
+### 5.1.5  Fire prevention and protection
+### 5.1.6  Media storage
+### 5.1.7  Waste disposal
+### 5.1.8  Off-site backup
+## 5.2  Procedural controls
+### 5.2.1  Trusted roles
+### 5.2.2  Number of persons required per task
+### 5.2.3  Identification and authentication for each role
+### 5.2.4  Roles requiring separation of duties
+## 5.3  Personnel controls
+### 5.3.1  Qualifications, experience, and clearance requirements
+### 5.3.2  Background check procedures
+### 5.3.3  Training requirements
+### 5.3.4  Retraining frequency and requirements
+### 5.3.5  Job rotation frequency and sequence
+### 5.3.6  Sanctions for unauthorized actions
+### 5.3.7  Independent contractor requirements
+### 5.3.8  Documentation supplied to personnel
+## 5.4  Audit logging procedures
+### 5.4.1  Types of events recorded
+### 5.4.2  Frequency of processing log
+### 5.4.3  Retention period for audit log
+### 5.4.4  Protection of audit log
+### 5.4.5  Audit log backup procedures
+### 5.4.6  Audit collection system (internal vs. external)
+### 5.4.7  Notification to event-causing subject
+### 5.4.8  Vulnerability assessments
+## 5.5  Records archival
+### 5.5.1  Types of records archived
+### 5.5.2  Retention period for archive
+### 5.5.3  Protection of archive
+### 5.5.4  Archive backup procedures
+### 5.5.5  Requirements for time-stamping of records
+### 5.5.6  Archive collection system (internal or external)
+### 5.5.7  Procedures to obtain and verify archive information
+## 5.6  Key changeover
+## 5.7  Compromise and disaster recovery
+### 5.7.1  Incident and compromise handling procedures
+### 5.7.2  Computing resources, software, and/or data are corrupted
+### 5.7.3  Entity private key compromise procedures
+### 5.7.4  Business continuity capabilities after a disaster
+## 5.8  CA or RA termination
+# 6.  TECHNICAL SECURITY CONTROLS (11)
+## 6.1  Key pair generation and installation
+### 6.1.1  Key pair generation
+### 6.1.2  Private key delivery to subscriber
+### 6.1.3  Public key delivery to certificate issuer
+### 6.1.4  CA public key delivery to relying parties
+### 6.1.5  Key sizes
+### 6.1.6  Public key parameters generation and quality checking
+### 6.1.7  Key usage purposes (as per X.509 v3 key usage field)
+## 6.2  Private Key Protection and Cryptographic Module Engineering Controls
+### 6.2.1  Cryptographic module standards and controls
+### 6.2.2  Private key (n out of m) multi-person control
+### 6.2.3  Private key escrow
+### 6.2.4  Private key backup
+### 6.2.5  Private key archival
+### 6.2.6  Private key transfer into or from a cryptographic module
+### 6.2.7  Private key storage on cryptographic module
+### 6.2.8  Method of activating private key
+### 6.2.9  Method of deactivating private key
+### 6.2.10 Method of destroying private key
+### 6.2.11 Cryptographic Module Rating
+## 6.3  Other aspects of key pair management
+### 6.3.1  Public key archival
+### 6.3.2  Certificate operational periods and key pair usage periods
+## 6.4  Activation data
+### 6.4.1  Activation data generation and installation
+### 6.4.2  Activation data protection
+### 6.4.3  Other aspects of activation data
+## 6.5  Computer security controls
+### 6.5.1  Specific computer security technical requirements
+### 6.5.2  Computer security rating
+## 6.6  Life cycle technical controls
+### 6.6.1  System development controls
+### 6.6.2  Security management controls
+### 6.6.3  Life cycle security controls
+## 6.7  Network security controls
+## 6.8  Time-stamping
+# 7.  CERTIFICATE, CRL, AND OCSP PROFILES
+## 7.1  Certificate profile
+### 7.1.1  Version number(s)
+### 7.1.2  Certificate extensions
+### 7.1.3  Algorithm object identifiers
+### 7.1.4  Name forms
+### 7.1.5  Name constraints
+### 7.1.6  Certificate policy object identifier
+### 7.1.7  Usage of Policy Constraints extension
+### 7.1.8  Policy qualifiers syntax and semantics
+### 7.1.9 Processing semantics for the critical Certificate Policies extension
+## 7.2  CRL profile
+### 7.2.1  Version number(s)
+### 7.2.2  CRL and CRL entry extensions
+## 7.3  OCSP profile
+### 7.3.1  Version number(s)
+### 7.3.2  OCSP extensions
+# 8.  COMPLIANCE AUDIT AND OTHER ASSESSMENTS
+## 8.1  Frequency or circumstances of assessment
+## 8.2  Identity/qualifications of assessor
+## 8.3  Assessor's relationship to assessed entity
+## 8.4  Topics covered by assessment
+## 8.5  Actions taken as a result of deficiency
+## 8.6  Communication of results
+# 9.  OTHER BUSINESS AND LEGAL MATTERS
+## 9.1  Fees
+### 9.1.1  Certificate issuance or renewal fees
+### 9.1.2  Certificate access fees
+### 9.1.3  Revocation or status information access fees
+### 9.1.4  Fees for other services
+### 9.1.5  Refund policy
+## 9.2  Financial responsibility
+### 9.2.1  Insurance coverage
+### 9.2.2  Other assets
+### 9.2.3  Insurance or warranty coverage for end-entities
+## 9.3  Confidentiality of business information
+### 9.3.1  Scope of confidential information
+### 9.3.2  Information not within the scope of confidential information
+### 9.3.3  Responsibility to protect confidential information
+## 9.4  Privacy of personal information
+### 9.4.1  Privacy plan
+### 9.4.2  Information treated as private
+### 9.4.3  Information not deemed private
+### 9.4.4  Responsibility to protect private information
+### 9.4.5  Notice and consent to use private information
+### 9.4.6 Disclosure pursuant to judicial or administrative process
+### 9.4.7  Other information disclosure circumstances
+## 9.5  Intellectual property rights
+## 9.6  Representations and warranties
+### 9.6.1  CA representations and warranties
+### 9.6.2  RA representations and warranties
+### 9.6.3  Subscriber representations and warranties
+### 9.6.4  Relying party representations and warranties
+### 9.6.5  Representations and warranties of other participants
+## 9.7  Disclaimers of warranties
+## 9.8  Limitations of liability
+## 9.9  Indemnities
+## 9.10  Term and termination
+### 9.10.1  Term
+### 9.10.2  Termination
+### 9.10.3  Effect of termination and survival
+## 9.11  Individual notices and communications with participants
+## 9.12  Amendments
+### 9.12.1  Procedure for amendment
+### 9.12.2  Notification mechanism and period
+### 9.12.3  Circumstances under which OID must be changed
+## 9.13  Dispute resolution provisions
+## 9.14  Governing law
+## 9.15  Compliance with applicable law
+## 9.16  Miscellaneous provisions
+### 9.16.1  Entire agreement
+### 9.16.2  Assignment
+### 9.16.3  Severability
+### 9.16.4  Enforcement (attorneys' fees and waiver of rights)
+### 9.16.5  Force Majeure
+## 9.17  Other provisions


### PR DESCRIPTION
* Add files via upload

* EVG.md

* Update EVG.md

* Create EVG original

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Delete EVG original

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG.md

* Update EVG to match section 6 of the RFC 3647.md

Updated section 1.1 from scope to overview
Added section 3.2.1 for the possesion of the private key Changed totally/created new section 3.2.2 to cover all section 11 Moved section 8.1 to section 8 and renamed the others to meet RFC3647 Added the self-audits (8.1.1) under section 8.1
Left/created section 8.7 for pre/readiness audits which do not exist under RFC 3647

* Update EVG updating links.md

2 links were updated regarding section 8

* Update EVG.md

Another link updated from 3.2.14.1 to 3.2.2.14.1

* Update branch for BRs pointing to new sections of EVGs (#476)

* Proposal: Make OCSP Optional, Require CRLs, and Incentivize Automatio… (#441)

* Proposal: Make OCSP Optional, Require CRLs, and Incentivize Automation / Short-Lived Certificates (#414)

* Profiles WIP

* Clarify AIA based on 2021-06-12 call

AIA allows multiple methods, and multiple instances of each method. However, client implementations use the ordering to indicate priority, as per RFC 5280, so clarify the requirements for multiple AccessDescriptions with the same accessMethod.

* Address basicConstraints for OCSP Responder feedback

Rather than make basicConstraints MUST, make it a MAY, to allow omission (plus v3) or presence (but empty) to indicate that it is not a CA certificate.

* Address the "any other value" situations with 7.1.2.4 language

This adopts the language from 7.1.2.4 to the various extensibility points, by trying to explicitly clarify as appropriate as to what is permitted.

* Fix the certificatePolicies mismatched highlighted by Corey

* Change SHOULD NOT to NOT RECOMMENDED

While RFC 2119 establishes that these two phrases are semantically equivalent, it's been suggested that this may resolve some anxiety around misinterpretations of SHOULD NOT as SHALL NOT, particularly by auditors.

By changing this to NOT RECOMMENDED, the same guidance is preserved, but it hopefully makes it more palatable to CAs.

See https://github.com/sleevi/cabforum-docs/pull/36/files#r856429830 for related discussion.

* Remove dnsSRV and cleanup otherName handling

This removes the (buggy) description of DNS SRV and leaves it overall as a SHOULD NOT and in scope of the (existing) 7.1.4.2 requirements. It also fixes up a typo (extension OID -> type-id)

* Formatting fix

* Move the Non-TLS EKU requirement into the Non-TLS profile

Originally it was part of the common fields, when there were multiple variations of non-TLS CAs. However, as there is only a single reference to this section, fold it in to the non-TLS profile.

This hopefully makes it clearer about the EKU requirements for non-TLS CAs (being what defines something as non-TLS), and reduces some confusion around non-TLS and TLS common sections.

* Redo Certificate Policies for Non-TLS CAs

The existing language was buggy, in that a link target was updated, but not the section heading. However, it was further buggy due to the interactions between Affiliated and Non-Affiliated CAs.

This overhauls it in line with the November and F2F discussions; unlike many of the other extensions in this section (which are dictated by RFC 5280 as being mandatory for certain situations), certificatePolicies is not, so this is demoted to a MAY.

However, the language from RFC 5280 does set out some guidance - such as not recommending that a policyQualifier be present - and so that requirement is preserved, under the argument that a non-TLS CA should still align with RFC 5280 if issued under a BR CA.

This does *remove* an existing BR requirement, namely those inherited from Section 7.1.6.3, but since that seemed to align with the intent of the SCWG, this should be a positive change.

* Naming Cleanup

This moves the metadata prohibition and domain name prohibition from applying to all certificates to only applying to Subscriber certificates (and in particular, to IV/OV/EV).

This also corrects the organizationalUnit name to reflect SC47v2.

* Formatting & Section Heading fixes

This fixes a few unnumbered sections (around validity periods) and adjusts the formatting for several tables to better accomodate the text.

* Fix a bug in non-TLS technically constrained CAs

For non-TLS CAs, don't allow them to assert the BR's CP OIDs, as the certificates will not be BR compliant.

* Redo Certificate Policies

This reworks the presentation and format of the certificatePolicies extensions, better aligning to the BRs, and hopefully providing sufficient clarity:

Relaxations:

- Reserved Policy OID is * no longer* required to be first, but is RECOMMENDED (SHOULD).
- The separation of "Affiliated" and "Unaffiliated" for certificate policies is removed. This was introduced for Cross-Certified Sub-CAs, but resulted in some ambiguity about what happens when a Technically Constrained (non-TLS or nameConstraints) Sub-CA is operated by a non-Affiliated entity. The requirements around Affiliation are now folded into a common section, rather than being two sections.
- Although not permitted by the current BRs, the cPSuri is now explicitly allowed for all certificate policies (_including_ for anyPolicy).
- anyPolicy is now explicitly permitted (but NOT RECOMMENDED) for OCSP Responders
- Reserved CABF OIDs are now explicitly permitted (but NOT RECOMMENDED) for OCSP Responders.

Clarifications:
- A note is added to the OCSP Responder section explaining that because CPs limit the validity and purposes of a certificate, it becomes possible to create an "invalid" responder that clients will reject (and thus also reject responses), and that this is part of the reason for forbidding.
- For TLS certificates, the requirements for CPs for sub-CAs versus leaf certificates had a slightly different wording: whether a given CP needed to be documented by the CA (e.g. could be any policy, including a reserved CP or anyPolicy) or needed to be _defined_ and documented by the CA (i.e. must be from the CA's own OID arc). This harmonizes the language for TLS ("defined by"), while still leaving a fairly large carveout for non-TLS ("documented").

* Minor fixes and cleanups (#399)

* Add order and encoding requirement for DC attribute

* Remove overly specific Cross-cert requirement; fix serialNumber encoding

* Clarify NC exclusion

* Remove "Domain Name or IP Address" validation requirement for now



* Integrate newer ballots (#406)

* Update README (#294)



* Adjust the workflow file to build the actions (#296)

This addresses a few requests that recently came up from the certificate profiles work:

- Remove the explicit retention period (of 21 days) to allow the GitHub default of 90 days.
- Change the generated ZIP file from being "BR.md-hash" to being "BR-hash".
- Allow manually invoking the workflow (via workflow_dispatch), in the event folks want to re-run for a particular branch (e.g. profiles)
- Attempt to resolve the "non-deterministic redline" noted by Jos. When a given commit is on cabforum/servercert, it may be both a commit (to a branch) and part of a pull request (to main). We want the pull request redline to be against main, while the commit redline to be against the previous commit. Because both jobs run, and both upload the same file name, this results in a non-deterministic clobbering, where the commit-redline may clobber the pr-redline. This changes the generated zip file to be "file-hash-event_type", so that it will generate redlines for both PRs and commits and attach both.

* SC47 Sunset subject:organizationalUnitName (#282) (#290)

* SC47 Sunset subject:organizationalUnitName (#282)

* Deprecation of subject:organizationalUnitName

* Update language to avoid confusion on the effective date

This version updates SC47 to state "issued on or after September 1, 2022" and makes the EV Guidelines reference the BRs as suggested by Ryan Sleevi from Google.





* SC47 datefix (#298)

* Update dates table

* Update EVG.md

Add SC47 reference to relevant dates table

* Fixup section number in prior commit




* SC48 - Domain Name and IP Address Encoding (#285) (#302)

* SC48 - Domain Name and IP Address Encoding (#285)

* First pass

* Add more RFC references, some wordsmithing

* Another few fixes

* Switch to use "LDH Labels"

* Propose concrete effective date

* Clarification about root zone trailing dot

* Replace "label" with "Domain Label" throughout (#1)

Replace "label" with "Domain Label" and "domain name" with "Domain Name" throughout




* Fix double negative

* Fix redundant "if the"





* Wrap xn-- to prevent ligaturization

* SC48 - Domain Name and IP Address Encoding (#285)

* First pass

* Add more RFC references, some wordsmithing

* Another few fixes

* Switch to use "LDH Labels"

* Propose concrete effective date

* Clarification about root zone trailing dot

* Replace "label" with "Domain Label" throughout (#1)

Replace "label" with "Domain Label" and "domain name" with "Domain Name" throughout




* Fix double negative

* Fix redundant "if the"





* Wrap xn-- to prevent ligaturization

* Update dates and version numbers






* Ballot SC50 - Remove the requirements of 4.1.1 (#328)

* SC50 - Remove the requirements of 4.1.1 (#323)

* Bump cairosvg from 1.0.20 to 2.5.1

Bumps [cairosvg](https://github.com/Kozea/CairoSVG) from 1.0.20 to 2.5.1.
- [Release notes](https://github.com/Kozea/CairoSVG/releases)
- [Changelog](https://github.com/Kozea/CairoSVG/blob/master/NEWS.rst)
- [Commits](https://github.com/Kozea/CairoSVG/compare/1.0.20...2.5.1)



* Bump kramdown from 2.3.0 to 2.3.1

Bumps [kramdown](https://github.com/gettalong/kramdown) from 2.3.0 to 2.3.1.
- [Release notes](https://github.com/gettalong/kramdown/releases)
- [Changelog](https://github.com/gettalong/kramdown/blob/master/doc/news.page)
- [Commits](https://github.com/gettalong/kramdown/commits)



* Remove 4.1.1; persist compromised keys in 6.1.1.3

Remove section 4.1.1 from the BRs
Explicitly require persistent access to compromised keys

* Rebase based on upstream/main

* Move System requirement to 6.1.1.3

* Add 4.1.1 as blank

* Remove capitalization from 6.1.1.3 where terms are not defined

* Re-add 'No stipulation.' to 4.1.1

* Remove change to 6.1.1.3




* Update version and date table






* Ballot SC53: Sunset SHA-1 for OCSP signing (#330) (#338)

* Sunset SHA-1 for OCSP signing (#330)

* Sunset SHA-1 OCSP signing

* Clarify necessity of both items

* Standardize date format, fix year in effective date table



* Update version, table, and date





* Bump actions/checkout from 2 to 3 (#342)

Bumps [actions/checkout](https://github.com/actions/checkout) from 2 to 3.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v2...v3)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-major ...





* Ballot SC51: Reduce and Clarify Log and Records Archival Retention Requirements (#347)

* Ballot SC51: Reduce and Clarify Audit Log and Records Archival Retention Requirements  (#336)

* Bump cairosvg from 1.0.20 to 2.5.1

Bumps [cairosvg](https://github.com/Kozea/CairoSVG) from 1.0.20 to 2.5.1.
- [Release notes](https://github.com/Kozea/CairoSVG/releases)
- [Changelog](https://github.com/Kozea/CairoSVG/blob/master/NEWS.rst)
- [Commits](https://github.com/Kozea/CairoSVG/compare/1.0.20...2.5.1)



* Bump kramdown from 2.3.0 to 2.3.1

Bumps [kramdown](https://github.com/gettalong/kramdown) from 2.3.0 to 2.3.1.
- [Release notes](https://github.com/gettalong/kramdown/releases)
- [Changelog](https://github.com/gettalong/kramdown/blob/master/doc/news.page)
- [Commits](https://github.com/gettalong/kramdown/commits)



* Restructure  parts of 5.4.x and 5.5.x

* Use 'events' consistently in 5.4.1

* Forgot to remove "revocation" as condition for start of retention period of Subscriber Certificates.

* Introduce possessive in 5.4.1 and 5.5.1 to better deliniate responsiblities of CAs using DTPs

* Remove WIP title;

* re-order list in 5.5.2; add 'or' clause to validation documentation archival list entry.

* Incorporate feedback from Aaron and Dimitris in Servercert-wg Discussion Period

Based on the feedback from Aaron here (https://lists.cabforum.org/pipermail/servercert-wg/2022-January/003115.html) and here (https://lists.cabforum.org/pipermail/servercert-wg/2022-January/003125.html), update 5.5.1 and 5.5.2. Based on the feedback from Dimitris here (https://lists.cabforum.org/pipermail/servercert-wg/2022-January/003110.html), update 5.4.3 and 5.5.2.

* Update link formatting in 5.4.1

The "Section" links throughout include the word "Section" in the link, except for in 5.4.1; this fixes that inconsistency.




* Update effective date and version number

* Update ballot table in document

* Fix date string






* Ballot SC54: Onion Cleanup (#369)

* SC-54: Onion cleanup (#348)

The voting on ballot SC54 has completed, and the ballot has passed.

Voting Results
Certificate Issuers
votes total, with no abstentions:
18 Yes votes: Amazon, Buypass, DigiCert, eMudhra, Entrust, GDCA, GlobalSign, GoDaddy, HARICA, Izenpe, JPRS, NAVER, OISTE, Sectigo, SwissSign, TrustCor, SecureTrust, Visa 0 No Votes
0 Abstentions
Certificate Consumers
6 votes total, with no abstentions:
6 Yes votes: 360, Apple, Cisco, Google, Microsoft, Mozilla 0 No votes
0 Abstentions

Bylaw Requirements
1.     Bylaw 2.3(f) requires:
·      A "yes" vote by two-thirds of Certificate Issuer votes and by 50%-plus-one of Certificate Consumer votes. Votes to abstain are not counted for this purpose.
This requirement was MET for Certificate Issuers and MET for Certificate Consumers.
·      At least one Certificate Issuer and one Certificate Consumer Member must vote in favor of a ballot for the ballot to be adopted.
This requirement was MET.
2.    Bylaw 2.3(g) requires that a ballot result only be considered valid when “more than half of the number of currently active Members has participated”. Votes to abstain are counted in determining quorum. Half of the currently active members at the start of voting was 14, so the quorum was 15 for this ballot.
This requirement was MET.

This ballot now enters the IP Rights Review Period to permit members to review the ballot for relevant IP rights issues.

——

* Addresses #270 allowing method 3.2.2.4.20 for `.onion` domains.

* Addresses #242 creating an exception for `.onion` domains, using existing language from the opening section of 3.2.2.4.

* Addresses #241 removing the currently deprecated Domain validation method 3.2.2.4.6.

* Addresses #240. Things are signed using private, not public keys.

* Addresses #190, #191. According to https://github.com/cabforum/servercert/issues/191#issuecomment-827810409,  effectively 2021-10-15 is when v2 stops working everywhere. We could proceed without an effective date, remove most of Appendix F in the EV Guidelines and point to Appendix B of the Baseline Requirements directly. No strong feelings either way.

* This is a mitigation against a malicious CA but the Applicant ultimately creates the Nonce. We agreed with Corey and Wayne to propose the removal of the  requirement for the CA to *confirm* entropy.

* Update language to deprecate legacy Appendix F validation method with "immediate" effect, after the ballot clears IPR (30 days after voting).

* remove double space

* Remove EVG Appendix F, introduce Onion Domain Name term

* A few more minor tweaks

* Fix numbering

* Update for easier read.

* Revert "Update for easier read."

This reverts commit 1bac785b2fd6a3fe0957434f9d13b13a47d4d19b.



* SC-54: Onion cleanup (#348)

The voting on ballot SC54 has completed, and the ballot has passed.

Voting Results
Certificate Issuers
votes total, with no abstentions:
18 Yes votes: Amazon, Buypass, DigiCert, eMudhra, Entrust, GDCA, GlobalSign, GoDaddy, HARICA, Izenpe, JPRS, NAVER, OISTE, Sectigo, SwissSign, TrustCor, SecureTrust, Visa 0 No Votes
0 Abstentions
Certificate Consumers
6 votes total, with no abstentions:
6 Yes votes: 360, Apple, Cisco, Google, Microsoft, Mozilla 0 No votes
0 Abstentions

Bylaw Requirements
1.     Bylaw 2.3(f) requires:
·      A "yes" vote by two-thirds of Certificate Issuer votes and by 50%-plus-one of Certificate Consumer votes. Votes to abstain are not counted for this purpose.
This requirement was MET for Certificate Issuers and MET for Certificate Consumers.
·      At least one Certificate Issuer and one Certificate Consumer Member must vote in favor of a ballot for the ballot to be adopted.
This requirement was MET.
2.    Bylaw 2.3(g) requires that a ballot result only be considered valid when “more than half of the number of currently active Members has participated”. Votes to abstain are counted in determining quorum. Half of the currently active members at the start of voting was 14, so the quorum was 15 for this ballot.
This requirement was MET.

This ballot now enters the IP Rights Review Period to permit members to review the ballot for relevant IP rights issues.

——

* Addresses #270 allowing method 3.2.2.4.20 for `.onion` domains.

* Addresses #242 creating an exception for `.onion` domains, using existing language from the opening section of 3.2.2.4.

* Addresses #241 removing the currently deprecated Domain validation method 3.2.2.4.6.

* Addresses #240. Things are signed using private, not public keys.

* Addresses #190, #191. According to https://github.com/cabforum/servercert/issues/191#issuecomment-827810409,  effectively 2021-10-15 is when v2 stops working everywhere. We could proceed without an effective date, remove most of Appendix F in the EV Guidelines and point to Appendix B of the Baseline Requirements directly. No strong feelings either way.

* This is a mitigation against a malicious CA but the Applicant ultimately creates the Nonce. We agreed with Corey and Wayne to propose the removal of the  requirement for the CA to *confirm* entropy.

* Update language to deprecate legacy Appendix F validation method with "immediate" effect, after the ballot clears IPR (30 days after voting).

* remove double space

* Remove EVG Appendix F, introduce Onion Domain Name term

* A few more minor tweaks

* Fix numbering

* Update for easier read.

* Revert "Update for easier read."

This reverts commit 1bac785b2fd6a3fe0957434f9d13b13a47d4d19b.



* Update version numbers and dates





* Integrate SC-48 CN requirements













* Update BR.md

Create dedicated branch and sync with "profiles" branch (as of Jan 17, 2023).

* Update BR.md

Address Comments:
- https://github.com/cabforum/servercert/pull/402#discussion_r1040210458 (added "CRL")
- https://github.com/cabforum/servercert/pull/414#discussion_r1073714166 (as suggested)

* Align with BRs

Inadvertent numbering change.

* Update BR.md

Add consideration for a phased reduction of short-lived subscriber certificate validity. 

(in response to https://github.com/cabforum/servercert/pull/414#discussion_r1073772243)

* Update BR.md

Cleaning-up proposal in advance of discussion.

* Update EVG.md

[clean-up diff, this file was not intentionally modified in the PR]

* Update BR.md

[clean-up]

* Update BR.md

[cleanup]

* Update BR.md

* Update BR.md

* Update BR.md

begin integrating SC-61 language.

* integrate sc61

* Update BR.md

continue tweaking to include sc61

* Update BR.md

improve readability

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

correct spelling error

* Update BR.md

* Update BR.md

typo

* Update BR.md

* Update BR.md

* Update BR.md

* Improve specificity of CRL issuance frequency

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

Typo (thanks, Wendy!)

* Update docs/BR.md

Editorial



* Update docs/BR.md

Editorial



* Update BR.md

* Update BR.md

* Update BR.md

Address comment from Aaron: "I'm not in favor of allowing CRLs to remain non-updated for 7 days because that is a regression from current OCSP behavior. Section 4.9.10.(4) makes it so that updated revocation information is always available "no later than four days after the thisUpdate". Therefore, a CA operating in a CRLs-only mode should be required to update their CRLs at least once every 4 days."

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update docs/BR.md



* Update docs/BR.md



* Update BR.md

"twenty four" -> "twenty-four"

* Update BR.md

* Add provision to handle nonces per RFC8954

* Update BR.md

Improve readability.

* Update BR.md

* Update BR.md

* Update BR.md

CAs issuing CA certificates should publish a new CRL if _any_ certificate is revoked, not just CA certificates.

This change is intended to force CRL publication in the event that a delegated OCSP responder's certificate was revoked (for example, due to key compromise).

* Address comment from Rob

* Clean up language

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Update BR.md

* Address formatting nits

* Address table formatting nits.

* Remove redundant language re: nextUpdate

* Clarify use of "unspecified" CRL Reason Code

* Clarify IDP

* (Further) Clarify IDP

* Update BR.md

Make sure that where the word "Certificate" was introduced in this proposal, it is capitalized correctly.

* Update BR.md

Nits.

---------
















* Update BR.md

---------

















* Fall 2023 clean up (#460)

* Issue#169

Issue #169 
- updated 3.2.2.5.6 and 3.2.2.5.7
- added RFC 8738 in References

* Issue #174

Issue #174 
- Updated title in section 3.2.2.4.10
- Updated section 3.2.2.4.18

* Issue #337

Issue #337 
- Updated title of the document to include TLS Server And also:
- updated section 1.1, 1.2, 1.5 and 2.2 to be consistent with the new document name

* Issue #423

Issue #423 
Updated section 1.6.3
- removing version of the Webtrust and changing the link to redirect to all the documents published by CPA Canada
- removing version of the NetSec and changing the link to redirect to the NetSec documents

* Issue #430

Issue #430 

Updated with the text suggested by Aaron as it´s the smallest change and clarifies the ambiguity of "reuse"

* Issue #444

Issue #444 

Added empty section 7.1.5

* Issue #450

Issue #450 
Updated including link to the 6.2.7 section

* Issue #453

Issue #453 

Updated section as indicated

* PR #415

PR #415 
Updated title

* Update BR.md

Change order of "pending prohibition" and "P-label" in section 1.6.3 definitions to follow alpahabetical order

* Update BR.md

Updated version and changelog

* Issue #461

Issue #461 
Used 2 option for the update

* Update docs/BR.md



* Add line breaks in 7.1.2.11.2

According to #462

* Revert the change of the NSSR version

Put back the version 1.7 in the NetSec

* Update BR.md

---------



---------

















* Update BRs with the new EVGs section numbers.md

Changed sections 3.2.2.4.7 and 7.1.2.7.5, updating the following: Section 3.2.2.4.7
EVG 11.14.3 to new 3.2.2.14.3

Section 7.1.2.7.5
EVG 9.2 to new 7.1.4.2

* Update EVG.md

Updated section 7.1.2.2 to fix the link to section 7.1.4.2.8

---------