### PR TITLE
Ballot SC-082:  Clarify CA Assisted DNS Validation under 3.2.2.4.7

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -314,6 +314,8 @@ The Definitions found in the CA/Browser Forum's Network and Certificate System S
 
 **CA Key Pair**: A Key Pair where the Public Key appears as the Subject Public Key Info in one or more Root CA Certificate(s) and/or Subordinate CA Certificate(s).
 
+**Canonical Authorization Domain Name**: The domain name found within the RDATA value of a CNAME record located at an Authorization Domain Name that is prefixed with a Domain Label that begins with an underscore character.
+
 **Certificate**: An electronic document that uses a digital signature to bind a public key and an identity.
 
 **Certificate Data**: Certificate requests and data related thereto (whether obtained from the Applicant or otherwise) in the CA's possession or control or to which the CA has access.
@@ -786,7 +788,7 @@ This method has been retired and MUST NOT be used. Prior validations using this 
 
 ##### 3.2.2.4.7 DNS Change
 
-Confirming the Applicant's control over the FQDN by confirming the presence of a Random Value or Request Token for either in a DNS CNAME, TXT or CAA record for either 1) an Authorization Domain Name; or 2) an Authorization Domain Name that is prefixed with a Domain Label that begins with an underscore character.
+Confirming the Applicant's control over the FQDN by confirming the presence of a Random Value or Request Token either in a DNS CNAME, TXT or CAA record for 1) an Authorization Domain Name; or 2) an Authorization Domain Name that is prefixed with a Domain Label that begins with an underscore character; or 3) a Canonical Authorization Domain Name.
 
 If a Random Value is used, the CA SHALL provide a Random Value unique to the Certificate request and SHALL not use the Random Value after
 
@@ -794,6 +796,11 @@ If a Random Value is used, the CA SHALL provide a Random Value unique to the Cer
   ii. if the Applicant submitted the Certificate request, the time frame permitted for reuse of validated information relevant to the Certificate (such as in [Section 4.2.1](#421-performing-identification-and-authentication-functions) of these Guidelines or Section 3.2.2.14.3 of the EV Guidelines).
 
 CAs using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same challenge information (i.e. Random Value or Request Token) as the Primary Network Perspective.
+
+CAs MAY operate domains for the purpose of assisting Applicants with this validation, and MAY instruct Applicants to add a CNAME record containing a Canonical Authorization Domain Name controlled by the CA. If the CA does so, the CA SHALL 
+  i. ensure that each Canonical Authorization Domain Name is used for a unique Applicant, and not shared across multiple Applicants; and 
+  ii. complete the validation within 8 hours of performing the DNS lookup; and
+  iii. prohibit A and AAAA records in the DNS zones the CA operates for assisting Applicants with this validation.
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 


### PR DESCRIPTION
Ballot SC-082: Clarify CA Assisted DNS Validation under 3.2.2.4.7

Previous Discussion Thread: 
https://github.com/slghtr-says/servercert/pull/1

### Background 

**CA Assisted DNS Validation** is the practice where Certification Authorities (CAs) instruct Applicants to create Canonical Name (CNAME) records specifically for the purpose of assisting the Applicant with Domain Control Verification (DCV) of their domain.

At F2F 59 (July 23’), the Validation Subcommittee of the Server Certificate WG presented the following conclusions on the practice of CA Assisted DNS Validation: 
* More clarity is needed around the practice
* Applicants generally delegate the performance of many aspects of operating a website.
* If done correctly, allowing Applicants to delegate the placement of the Random Value/ Request Token boosts agility and automation. 
* There are reasonable interpretations of the BRs that such delegation is already allowed today. 

A Tiger Team was formed to threat model CA Assisted DNS Validation and propose modifications to the BRs to add clarity and constraints around the practice. The results of the threat model exercise [1] were presented and discussed at F2F 60 [2] and F2F 61 [3].

### Purpose of Ballot 

The purpose of this ballot is to clarify the practice of CA Assisted DNS Validation and add constraints under Method 7 (3.2.4.4.7 DNS Change). Modification of other domain validation methods and the introduction of new domain validation methods are not in scope of this ballot but may be addressed in a future ballot. 

### Overview of Changes 
* New definition: Canonical Authorization Domain Name
* Addition of Canonical Authorization Domain Names into section 3.2.2.4.7 (DNS Change)
* Addition of constraints around the usage of Canonical Authorization Domain Names by CAs
  * Unique to an Applicant and not shared with multiple Applicants
  * DNS lookup results expire after 8 hours 
  * Restrictions on the type of DNS records located in zones for this purpose.

### Example

**Canonical Authorization Domain Name**: The domain name found within the RDATA value of a CNAME record located at an Authorization Domain Name that is prefixed with a Domain Label that begins with an underscore character.

Given an attempt to perform DCV for ``example.com`` using 3.2.2.4.7, 

The applicant inserts the following resource record in the public DNS zone of ``example.com``:

``_underscore-prefixed-domain-label.example.com. IN CNAME account-binding-id.cadomain.com``

where ``account-binding-id.cadomain.com`` is a resource record of the following form:

``account-binding-id.cadomain.com IN TXT <RDATA containing random value or request token>`` or
``account-binding-id.cadomain.com IN CNAME <RDATA containing random value or request token>`` or
``account-binding-id.cadomain.com IN CAA <RDATA containing random value or request token>``

then

``account-binding-id.cadomain.com`` is the **Canonical Authorization Domain Name**.

### References

[1] Threat Modeling: 
Validation SC Threat Modeling Doc: https://docs.google.com/document/d/1G2GYb0eg0rqE23f844J8qs7RYGU1jFVDsU5Pf7UYg3g/edit

[2] F2F-60 Presentation: https://docs.google.com/presentation/d/1M80h1N7MpBuqvZS0FdtJ_zj-AsaFxu7BNBSUJ6Ia5jU/edit?usp=sharing

[3] F2F-61 Presentation: https://docs.google.com/presentation/d/1rKW7I5jOYh37jQFtd1S-fKIs0j-dCAyUUU-fq_C8UKw/edit?usp=sharing

### How can you help?

  * Better: Add comments to this Pull Request.
  * Best: Add suggested edits directly to this Pull Request.
