### PR TITLE
Auto-comment on new issues stating which TLS BR and EVG versions were…

### DIFF
--- a/.github/workflows/tag-version-at-issue-creation.yml
+++ b/.github/workflows/tag-version-at-issue-creation.yml
@@ -1,0 +1,36 @@
+name: Reference TLS BR and EVG version upon issue creation
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  tls-evg-version:
+    name: Reference TLS BR and EVG version upon issue creation
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Read version from TLS BR
+      id: read_tlsbr_version
+      run: |
+        subtitle=$(grep -Po '(?<=subtitle:\s).*$' docs/BR.md | tr -d '\r')
+        echo "tlsbr_version=$subtitle" >> $GITHUB_OUTPUT
+
+    - name: Read version from EVG
+      id: read_evg_version
+      run: |
+        subtitle=$(grep -Po '(?<=subtitle:\s).*$' docs/EVG.md | tr -d '\r')
+        echo "evg_version=$subtitle" >> $GITHUB_OUTPUT
+        
+    - name: Add comment to issue
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        issue-number: ${{ github.event.issue.number }}
+        body: |
+          This issue was created based on:
+          - TLS BR ${{ steps.read_tlsbr_version.outputs.tlsbr_version }}
+          - EVG ${{ steps.read_evg_version.outputs.evg_version }}
+          


### PR DESCRIPTION
… active at the time

This will add the following automatically on new issues:
![image](https://github.com/cabforum/servercert/assets/18657429/dd1d0bac-900d-4d06-be5d-e6ab548db3c7)
