### PR TITLE
The title of section 1.2.2 is missing the section number as a prefix

### DIFF
--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -84,7 +84,7 @@ These Guidelines do not address the verification of information, or the issuance
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 
-## Relevant Dates
+### 1.2.2 Relevant Dates
 
 | **Compliance** | **Section(s)** | **Summary Description (See Full Text for Details)** |
 |--|--|----------|


### PR DESCRIPTION
Added the missing section number to the title of section 1.2.2 to ensure consistency and clarity in the document structure.

This change synchronizes the title with the TLS Baseline Requirements.