### PR TITLE
Sunset WHOIS [Version .1]

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
 
-subtitle: Version 2.0.7
+subtitle: Version 2.0.X
 author:
   - CA/Browser Forum
 
-date: 6-September-2024  
+date: DD-MONTH-2024  
 
 
 
@@ -144,6 +144,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.0.5 | SC73 | Compromised and weak keys | 3-May-2024 | 1-July-2024 |
 | 2.0.6 | SC75 | Pre-sign linting | 28-June-2024 | 6-August-2024 |
 | 2.0.7 | SC67 | Require Multi-Perspective Issuance Corroboration | 2-August-2024 | 6-September-2024 |
+| 2.0.X | SCXX | Sunset use of WHOIS to identify Domain Contacts | TBD | TBD |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 
@@ -197,10 +198,11 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2023-09-15     | Section 7 (and others)    | CAs MUST use the updated Certificate Profiles passed in Version 2.0.0                                                                                                                                                                                                                                                                                                                                                                                    |
 | 2024-03-15     | 4.9.7                     | CAs MUST generate and publish CRLs.                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | 2024-09-15     | 4.3.1.2                   | The CA SHOULD implement a Linting process to test the technical conformity of the to-be-issued Certificate with these Requirements.                                                                                                                                                                                                                                                                                                                      |
+| 2024-11-1      | 3.2.2.4                   | CAs MUST NOT rely on WHOIS to identify Domain Contacts. |
+
 | 2025-03-15     | 4.3.1.2                   | The CA SHALL implement a Linting process to test the technical conformity of the to-be-issued Certificate with these Requirements.                                                                                                                                                                                                                                                                                                                       |
 | 2025-03-15     | 8.7                       | The CA SHOULD use a Linting process to test the technical accuracy of already issued Certificates against the sample set chosen for Self-Audits.                                                                                                                                                                                                                                                                                                         |
 | 2025-03-15     | 3.2.2.9                   | CAs MUST corroborate the results of domain validation and CAA checks from multiple Network Perspectives where specified. |
-
 
 ## 1.3 PKI Participants
 
@@ -749,6 +751,8 @@ The Random Value SHALL remain valid for use in a confirming response for no more
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
+Effective November 1, 2024, validations using this method MUST NOT rely on WHOIS to identify Domain Contact information.
+
 ##### 3.2.2.4.3 Phone Contact with Domain Contact
 
 This method has been retired and MUST NOT be used. Prior validations using this method and validation data gathered according to this method SHALL NOT be used to issue certificates.
@@ -770,6 +774,8 @@ The email MAY be re-sent in its entirety, including the re-use of the Random Val
 The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
+
+Effective November 1, 2024, validations using this method MUST NOT rely on WHOIS to identify Domain Contact information.
 
 ##### 3.2.2.4.5 Domain Authorization Document
 
@@ -818,6 +824,8 @@ Confirming the Applicant's control over the FQDN by validating the Applicant is 
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
+Effective November 1, 2024, validations using this method MUST NOT rely on WHOIS to identify Domain Contact information.
+
 ##### 3.2.2.4.13 Email to DNS CAA Contact
 
 Confirming the Applicant's control over the FQDN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS CAA Email Contact. The relevant CAA Resource Record Set MUST be found using the search algorithm defined in RFC 8659, Section 3.
@@ -853,6 +861,8 @@ In the event of reaching voicemail, the CA may leave the Random Value and the AD
 The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
+
+Effective November 1, 2024, validations using this method MUST NOT rely on WHOIS to identify Domain Contact information.
 
 ##### 3.2.2.4.16 Phone Contact with DNS TXT Record Phone Contact
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -751,7 +751,7 @@ The Random Value SHALL remain valid for use in a confirming response for no more
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
-Effective November 1, 2024, validations using this method MUST NOT rely on WHOIS to identify Domain Contact information.
+Effective November 1, 2024, Subscriber Certificates MUST NOT be issued that rely on WHOIS to identify Domain Contact information. Prior validations using WHOIS to identify Domain Contact information MUST NOT be used to issue new Subscriber Certificates, regardless of permitted data reuse periods.
 
 ##### 3.2.2.4.3 Phone Contact with Domain Contact
 
@@ -774,8 +774,6 @@ The email MAY be re-sent in its entirety, including the re-use of the Random Val
 The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
-
-Effective November 1, 2024, validations using this method MUST NOT rely on WHOIS to identify Domain Contact information.
 
 ##### 3.2.2.4.5 Domain Authorization Document
 
@@ -824,7 +822,7 @@ Confirming the Applicant's control over the FQDN by validating the Applicant is 
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
-Effective November 1, 2024, validations using this method MUST NOT rely on WHOIS to identify Domain Contact information.
+Effective November 1, 2024, Subscriber Certificates MUST NOT be issued that rely on WHOIS to identify Domain Contact information. Prior validations using WHOIS to identify Domain Contact information MUST NOT be used to issue new Subscriber Certificates, regardless of permitted data reuse periods.
 
 ##### 3.2.2.4.13 Email to DNS CAA Contact
 
@@ -862,7 +860,7 @@ The Random Value SHALL remain valid for use in a confirming response for no more
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
-Effective November 1, 2024, validations using this method MUST NOT rely on WHOIS to identify Domain Contact information.
+Effective November 1, 2024, Subscriber Certificates MUST NOT be issued that rely on WHOIS to identify Domain Contact information. Prior validations using WHOIS to identify Domain Contact information MUST NOT be used to issue new Subscriber Certificates, regardless of permitted data reuse periods.
 
 ##### 3.2.2.4.16 Phone Contact with DNS TXT Record Phone Contact
 


### PR DESCRIPTION
All,

In light of recent events where research from WatchTowr Labs demonstrated how threat actors could exploit WHOIS to obtain fraudulently issued TLS certificates [1] and follow-on discussions in MDSP [2][3], we drafted an introductory proposal [4] to sunset the use of WHOIS for identifying Domain Contacts.

The proposal sets a prohibition against relying on WHOIS to identify Domain Contacts beginning 11/1/2024.

While publicly-trusted CA Owners are required to disclose and maintain in-use DCV methods to the CCADB [5], the collected data lacks specificity, hindering our ability to assess the extent of reliance on WHOIS and the potential impact of transitioning away from it.

Feedback on the proposal (preferably using comments or suggestions on this Pull Request via GitHub) along with volunteers for endorsers would be appreciated.

Thanks,
Ryan

P.S., I apologize if this effort is redundant to discussions already taking place in the Forum, I was traveling last week and am catching up on email.

[1] https://labs.watchtowr.com/we-spent-20-to-achieve-rce-and-accidentally-became-the-admins-of-mobi/
[2] https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/FuOi_uhQB6U
[3] https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/mAl9XjieSkA
[4] https://github.com/cabforum/servercert/compare/main...ryancdickson:staging:sunset-whois?expand=1
[5] https://docs.google.com/spreadsheets/d/1IXL8Yk12gPQs8GXiosXCPLPgATJilaiVy-f9SbsMA28/edit?gid=268412787#gid=268412787