### PR TITLE
Ballot SC-080 V3: "Sunset the use of WHOIS to identify Domain Contacts and relying DCV Methods"

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -839,7 +839,7 @@ Effective January 15, 2025:
 - When obtaining Domain Contact information for a requested Domain Name the CA:
      - if using the WHOIS protocol (RFC 3912), MUST query IANA's WHOIS server and follow referrals to the appropriate WHOIS server.
      - if using the Registry Data Access Protocol (RFC 7482), MUST utilize IANA's bootstrap file to identify and query the correct RDAP server for the domain.
-     - MUST NOT rely on cached 1) WHOIS server information or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
+     - MUST NOT rely on cached 1) WHOIS server information that is more than 48 hours old, or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
 
 ##### 3.2.2.4.13 Email to DNS CAA Contact
 
@@ -882,7 +882,7 @@ Effective January 15, 2025:
 - When obtaining Domain Contact information for a requested Domain Name the CA:
      - if using the WHOIS protocol (RFC 3912), MUST query IANA's WHOIS server and follow referrals to the appropriate WHOIS server.
      - if using the Registry Data Access Protocol (RFC 7482), MUST utilize IANA's bootstrap file to identify and query the correct RDAP server for the domain.
-     - MUST NOT rely on cached 1) WHOIS server information or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
+     - MUST NOT rely on cached 1) WHOIS server information that is more than 48 hours old, or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
 
 Effective July 15, 2025:
 - The CA MUST NOT rely on this method.

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
 
-subtitle: Version 2.0.8
+subtitle: Version 2.0.X
 author:
   - CA/Browser Forum
 
-date: 2-October-2024  
+date: DD-MONTH-2024  
 
 
 
@@ -145,6 +145,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.0.6 | SC75 | Pre-sign linting | 28-June-2024 | 6-August-2024 |
 | 2.0.7 | SC67 | Require Multi-Perspective Issuance Corroboration | 2-August-2024 | 6-September-2024 |
 | 2.0.8 | SC77 | Update WebTrust Audit name in Section 8.4 and References | 2-September-2024 | 2-October-2024 |
+| 2.0.X | SC80 | Strengthen WHOIS lookups and Sunset Methods 3.2.2.4.2 and 3.2.2.4.15 | TBD | TBD |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 
@@ -198,10 +199,11 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2023-09-15     | Section 7 (and others)    | CAs MUST use the updated Certificate Profiles passed in Version 2.0.0                                                                                                                                                                                                                                                                                                                                                                                    |
 | 2024-03-15     | 4.9.7                     | CAs MUST generate and publish CRLs.                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | 2024-09-15     | 4.3.1.2                   | The CA SHOULD implement a Linting process to test the technical conformity of the to-be-issued Certificate with these Requirements.                                                                                                                                                                                                                                                                                                                      |
+| 2025-01-15     | 3.2.2.4                   | CAs MUST NOT rely on HTTPS websites to identify Domain Contact information. CAs MUST rely on IANA resources for identifying Domain Contact information.                                                                                                                                                                                                                                                                                                  |
 | 2025-03-15     | 4.3.1.2                   | The CA SHALL implement a Linting process to test the technical conformity of the to-be-issued Certificate with these Requirements.                                                                                                                                                                                                                                                                                                                       |
 | 2025-03-15     | 8.7                       | The CA SHOULD use a Linting process to test the technical accuracy of already issued Certificates against the sample set chosen for Self-Audits.                                                                                                                                                                                                                                                                                                         |
-| 2025-03-15     | 3.2.2.9                   | CAs MUST corroborate the results of domain validation and CAA checks from multiple Network Perspectives where specified. |
-
+| 2025-03-15     | 3.2.2.9                   | CAs MUST corroborate the results of domain validation and CAA checks from multiple Network Perspectives where specified.       |
+| 2025-07-15     | 3.2.2.4                   | CAs MUST NOT rely on Methods 3.2.2.4.2 and 3.2.2.4.15 to issue Subscriber Certificates.                                        |
 
 ## 1.3 PKI Participants
 
@@ -752,6 +754,17 @@ The Random Value SHALL remain valid for use in a confirming response for no more
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
+Effective January 15, 2025:
+- When issuing Subscriber Certificates, the CA MUST NOT rely on Domain Contact information obtained using an HTTPS website, regardless of whether previously obtained information is within the allowed reuse period.
+- When obtaining Domain Contact information for a requested Domain Name the CA:
+     - if using the WHOIS protocol (RFC 3912), MUST query IANA's WHOIS server and follow referrals to the appropriate WHOIS server.
+     - if using the Registry Data Access Protocol (RFC 7482), MUST utilize IANA's bootstrap file to identify and query the correct RDAP server for the domain.
+     - MUST NOT rely on cached 1) WHOIS server information or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
+
+Effective July 15, 2025:
+- The CA MUST NOT rely on this method.
+- Prior validations using this method and validation data gathered according to this method MUST NOT be used to issue Subscriber Certificates.
+
 ##### 3.2.2.4.3 Phone Contact with Domain Contact
 
 This method has been retired and MUST NOT be used. Prior validations using this method and validation data gathered according to this method SHALL NOT be used to issue certificates.
@@ -821,6 +834,13 @@ Confirming the Applicant's control over the FQDN by validating the Applicant is 
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
+Effective January 15, 2025:
+- When issuing Subscriber Certificates, the CA MUST NOT rely on Domain Contact information obtained using an HTTPS website, regardless of whether previously obtained information is within the allowed reuse period.
+- When obtaining Domain Contact information for a requested Domain Name the CA:
+     - if using the WHOIS protocol (RFC 3912), MUST query IANA's WHOIS server and follow referrals to the appropriate WHOIS server.
+     - if using the Registry Data Access Protocol (RFC 7482), MUST utilize IANA's bootstrap file to identify and query the correct RDAP server for the domain.
+     - MUST NOT rely on cached 1) WHOIS server information or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
+
 ##### 3.2.2.4.13 Email to DNS CAA Contact
 
 Confirming the Applicant's control over the FQDN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS CAA Email Contact. The relevant CAA Resource Record Set MUST be found using the search algorithm defined in RFC 8659, Section 3.
@@ -856,6 +876,17 @@ In the event of reaching voicemail, the CA may leave the Random Value and the AD
 The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
+
+Effective January 15, 2025:
+- When issuing Subscriber Certificates, the CA MUST NOT rely on Domain Contact information obtained using an HTTPS website, regardless of whether previously obtained information is within the allowed reuse period.
+- When obtaining Domain Contact information for a requested Domain Name the CA:
+     - if using the WHOIS protocol (RFC 3912), MUST query IANA's WHOIS server and follow referrals to the appropriate WHOIS server.
+     - if using the Registry Data Access Protocol (RFC 7482), MUST utilize IANA's bootstrap file to identify and query the correct RDAP server for the domain.
+     - MUST NOT rely on cached 1) WHOIS server information or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
+
+Effective July 15, 2025:
+- The CA MUST NOT rely on this method.
+- Prior validations using this method and validation data gathered according to this method MUST NOT be used to issue Subscriber Certificates.
 
 ##### 3.2.2.4.16 Phone Contact with DNS TXT Record Phone Contact
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -759,7 +759,7 @@ Effective January 15, 2025:
 - When obtaining Domain Contact information for a requested Domain Name the CA:
      - if using the WHOIS protocol (RFC 3912), MUST query IANA's WHOIS server and follow referrals to the appropriate WHOIS server.
      - if using the Registry Data Access Protocol (RFC 7482), MUST utilize IANA's bootstrap file to identify and query the correct RDAP server for the domain.
-     - MUST NOT rely on cached 1) WHOIS server information or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
+     - MUST NOT rely on cached 1) WHOIS server information that is more than 48 hours old, or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
 
 Effective July 15, 2025:
 - The CA MUST NOT rely on this method.


### PR DESCRIPTION
[**Note:** This Pull Request will be used to facilitate a discussion period for Ballot SC-080 V3, planned to begin tomorrow (October 22, 2024)].

**Purpose of Ballot SC-080 V3:** This ballot proposes updates to the Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates (TLS BRs) to address concerns regarding the use of WHOIS and HTTPS websites for identifying Domain Contacts.

**Background:** This ballot intends to accomplish two objectives, originally described in [1].

_Objective 1: Enhance WHOIS/RDAP validation of gTLDs with comparable security properties to DNS-based validation._

_Justification:_
- A recent disclosure [2] demonstrated how threat actors could exploit deficiencies in the WHOIS protocol and WHOIS tools served via HTTPS websites to obtain fraudulent TLS certificates.
- Discussions within the Mozilla Dev Security Policy (MDSP) community [3] further expressed corresponding risks related to WHOIS, while also noting that ccTLDs may not maintain accurate or up-to-date WHOIS server records. Several examples of inoperative WHOIS servers for ccTLDs were identified.
- Solutions to strengthen existing WHOIS lookup methods were proposed in [5] and some are considered in this ballot.

_Objective 2: Sunset Methods 3.2.2.4.2 (“Email, Fax, SMS, or Postal Mail to Domain Contact”) and 3.2.2.4.15 (“Phone Contact with Domain Contact”)._

_Justification:_
- While solutions to strengthen WHOIS-relying DCV methods are considered in this ballot (see above), there is limited public evidence of significant reliance on these methods, including in response to [3] and [6]. 
- Instead, discussion has identified at least one CA Owner has already sunset reliance on WHOIS [7], and another that has changed its approach [8] for relying on WHOIS since disclosure of [2].
- More modern and heavily relied-upon DCV methods offer advantages over the existing WHOIS-based methods, including greater opportunity for seamless certificate lifecycle management automation (e.g., [9] and [10]), while also benefiting from recently improved security practices [11]. These methods can also more effectively align subscriber capabilities with agility and resilience expectations necessary to respond to the revocation timelines described in the TLS BRs [12]. 
- Beyond the above, previous discussions within the CA/Browser Forum have raised concerns about the perceived value (e.g., [13]) and security (e.g., [14]) of the DCV methods relying on WHOIS, further supporting the rationale for their gradual sunset.

**Benefits of adoption:**
- Enhanced Security: Eliminates reliance on outdated and vulnerable DCV methods that cannot consistently provide the security required by the TLS BRs, or benefit from recent DCV security enhancements (i.e., Multi-Perspective Issuance Corroboration [11]).   
- Increased Agility: Encourages site owners to transition to modern DCV methods, creating opportunities for faster, more efficient, and less error-prone certificate lifecycle management.   
- Opportunity for Innovation: Promotes the development of new and/or improved DCV methods, fostering innovation that may enhance the overall security and agility of the ecosystem.
 
**Proposed Key Dates:** The effective dates considered in this update are intended to 1) address the immediate concerns identified by [2], and 2) offer near-term and longer-term transition periods for subscribers and CA Owners relying on existing implementations of these methods.

January 15, 2025: For Methods 3.2.2.4.2, 3.2.2.4.12, and 3.2.2.4.15...
- CAs MUST NOT rely on Domain Contact information obtained using an HTTPS website, regardless of whether previously obtained information is within the allowed reuse period.
- When obtaining Domain Contact information for a requested Domain Name using the WHOIS protocol (RFC 3912) or the Registry Data Access Protocol (RFC 7482), the CA must follow specific practices (described in the ballot).
- CAs MUST NOT rely on cached 1) WHOIS server information that is more than 48 hours old, or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.

July 15, 2025: 
- CAs MUST NOT issue subscriber certificates relying on Methods 3.2.2.4.2 ("Email, Fax, SMS, or Postal Mail to Domain Contact") or 3.2.2.4.15 ("Phone Contact with Domain Contact").
- Prior validations using these methods and validation data gathered therein MUST NOT be used to issue new Subscriber Certificates.

**Proposal Revision History:**
- Pre-Ballot Version 1 [4]
- Version 1 Ballot and discussion [15]
- Version 2 Pre-Release [17] and discussion [18]
- Version 2 Ballot [19] and discussion [20]
- Version 3 Pre-Release [21] 
- Version 3 (introduced by this Pull Request)

**References:**
[1] https://archive.cabforum.org/pipermail/servercert-wg/2024-September/004900.html 
[2] https://labs.watchtowr.com/we-spent-20-to-achieve-rce-and-accidentally-became-the-admins-of-mobi/ 
[3] https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/FuOi_uhQB6U/m/hKJOz3XzAAAJ 
[4] https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/mAl9XjieSkA/m/oDNWxtPwAQAJ 
[5] https://archive.cabforum.org/pipermail/servercert-wg/2024-September/004839.html 
[6] https://archive.cabforum.org/pipermail/servercert-wg/2024-September/004844.html 
[7] https://aws.amazon.com/blogs/security/aws-certificate-manager-will-discontinue-whois-lookup-for-email-validated-certificates/ 
[8] https://bugzilla.mozilla.org/show_bug.cgi?id=1917896 
[9] https://cabforum.org/working-groups/server/baseline-requirements/requirements/#32247-dns-change 
[10] https://cabforum.org/working-groups/server/baseline-requirements/requirements/#322419-agreed-upon-change-to-website---acme 
[11] https://cabforum.org/working-groups/server/baseline-requirements/requirements/#3229-multi-perspective-issuance-corroboration 
[12] https://cabforum.org/working-groups/server/baseline-requirements/requirements/#491-circumstances-for-revocation 
[13] https://archive.cabforum.org/pipermail/servercert-wg/2018-August/000113.html 
[14] https://lists.cabforum.org/pipermail/validation/2024-July/001995.html 
[15] https://archive.cabforum.org/pipermail/servercert-wg/2024-September/004825.html 
[16] https://github.com/ryancdickson/staging/compare/356799f0dcfe11deb0a375a11233403236ab72c9..7a2ea7b33611bebf006a99a9a82729f183143eac 
[17] https://github.com/ryancdickson/staging/compare/ba28d04894d69c8fac62850b9d0de5061658c7c5..7a2ea7b33611bebf006a99a9a82729f183143eac 
[18] https://github.com/ryancdickson/staging/pull/9 
[19] https://github.com/cabforum/servercert/compare/ba28d04894d69c8fac62850b9d0de5061658c7c5..7f2b54cfa5b89f41458a88211566ce508c464804 
[20] https://groups.google.com/a/groups.cabforum.org/g/servercert-wg/c/AyTKMqwbCzc/m/MZ1CwW5nAQAJ
[21] https://groups.google.com/a/groups.cabforum.org/g/servercert-wg/c/AyTKMqwbCzc/m/hjUhnaJsAgAJ
