### PR TITLE
SC-084: DNS Labeled With ACME Account ID Challenge

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
 
-subtitle: Version 2.1.3
+subtitle: Version 2.1.4
 author:
   - CA/Browser Forum
 
-date: 24-February-2025
+date: 27-February-2025
 
 copyright: |
   Copyright 2025 CA/Browser Forum
@@ -147,6 +147,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.1.1    | SC79       | Allow more than one Certificate Policy in a Cross-Certified Subordinate CA Certificate | 30-Sep-2024 | 14-Nov-2024                       |
 | 2.1.2    | SC80       | Strengthen WHOIS lookups and Sunset Methods 3.2.2.4.2 and 3.2.2.4.15                   | 7-Nov-2024  | 16-Dec-2024                       |
 | 2.1.3    | SC83       | Winter 2024-2025 Cleanup Ballot                                                        | 23-Jan-2025 | 24-Feb-2025                       |
+| 2.1.4    | SC84       | DNS Labeled with ACME Account ID Validation Method                                     | 28-Jan-2025 | 27-Feb-2025                       |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -981,6 +981,16 @@ Except for Onion Domain Names, CAs performing validations using this method MUST
 
 **Note**: Once the FQDN has been validated using this method, the CA MUST NOT issue Certificates for other FQDNs that end with all the labels of the validated FQDN unless the CA performs separate validations for each of those other FQDNs using authorized methods. This method is NOT suitable for validating Wildcard Domain Names.
 
+##### 3.2.2.4.21 DNS Labeled with Account ID - ACME
+
+Confirming the Applicant's control over the FQDN by performing the procedure documented for a “dns-account-01” challenge in draft 00 of “Automated Certificate Management Environment (ACME) DNS Labeled With ACME Account ID Challenge,” available at [https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/).
+
+The token (as defined in draft 00 of “Automated Certificate Management Environment (ACME) DNS Labeled With ACME Account ID Challenge,” Section 3.1) MUST NOT be used for more than 30 days from its creation. The CPS MAY specify a shorter validity period for the token, in which case the CA MUST follow its CPS.
+
+Except for Onion Domain Names, CAs using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same token as the Primary Network Perspective.
+
+**Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
+
 #### 3.2.2.5 Authentication for an IP Address
 
 This section defines the permitted processes and procedures for validating the Applicant’s ownership or control of an IP Address listed in a Certificate.

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -5,7 +5,7 @@ subtitle: Version 2.1.4
 author:
   - CA/Browser Forum
 
-date: 27-February-2025
+date: 1-March-2025
 
 copyright: |
   Copyright 2025 CA/Browser Forum
@@ -147,7 +147,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.1.1    | SC79       | Allow more than one Certificate Policy in a Cross-Certified Subordinate CA Certificate | 30-Sep-2024 | 14-Nov-2024                       |
 | 2.1.2    | SC80       | Strengthen WHOIS lookups and Sunset Methods 3.2.2.4.2 and 3.2.2.4.15                   | 7-Nov-2024  | 16-Dec-2024                       |
 | 2.1.3    | SC83       | Winter 2024-2025 Cleanup Ballot                                                        | 23-Jan-2025 | 24-Feb-2025                       |
-| 2.1.4    | SC84       | DNS Labeled with ACME Account ID Validation Method                                     | 28-Jan-2025 | 27-Feb-2025                       |
+| 2.1.4    | SC84       | DNS Labeled with ACME Account ID Validation Method                                     | 28-Jan-2025 | 1-Mar-2025                       |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -987,7 +987,7 @@ Confirming the Applicant's control over the FQDN by performing the procedure doc
 
 The token (as defined in draft 00 of “Automated Certificate Management Environment (ACME) DNS Labeled With ACME Account ID Challenge,” Section 3.1) MUST NOT be used for more than 30 days from its creation. The CPS MAY specify a shorter validity period for the token, in which case the CA MUST follow its CPS.
 
-Except for Onion Domain Names, CAs using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same token as the Primary Network Perspective.
+CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same token as the Primary Network Perspective.
 
 **Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 


### PR DESCRIPTION
I would like to add a new DNS-based validation method to the TLS BRs. This method is similar to the ACME dns-01 challenge, but it solves a significant automation challenge. Large organizations often run a service on multiple cloud providers, These cloud providers typically automate the 3.2.2.4.7 DNS validation method by asking the website operator to delegate a CNAME record to them. Unfortunately, the ACME dns-01 challenge hard-codes the prepended label on the validation domain name as “_acme-challenge”, and DNS standards only allow one CNAME per zone, thus creating the conflict that the new method solves.

A draft RFC that addresses this problem was originally proposed in 2022. It has gone through a few iterations, ending up at the current draft at https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/. The mechanism for making the CNAME unique uses an additional prepended label that is calculated based on the ACME account ID. This approach aligns this method with similar domain name validation techniques documented by the DNS Operations WG at https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/. (note that the scoping mechanism in the DNSOP draft has been removed because it adds complexity and scope creep here).

The new dns-account-01 validation mechanism is [arguably] not permitted under the existing TLS BR 3.2.2.4.7 because of the second prepended label. The current language implies that only one label is allowed: “an Authorization Domain Name that is prefixed with a Domain Label that begins with an underscore character.”

Rather than solve this by modifying the existing DNS method, the Validation SC has previously discussed that we’d prefer to add a new method.

I would like to point out that there is precedence for incorporating a draft standard validation method into the BRs - this was done for both http-01 and tls-alpn-01 for IP addresses. I have waited to propose this ballot until the draft RFC stabilized. Given the minimal feedback received (https://mailarchive.ietf.org/arch/msg/acme/C-seFRSmAjnxWQfh0RTjSxhCb0A/) since the latest version was published, I believe we can and should proceed to incorporate this method into the BRs.
