### PR TITLE
Bump workflow versions

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Checkout old version for redline
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
         uses: actions/checkout@v4

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.push.before }}
           path: old/
-      - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.2.0
+      - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.2.1
         id: build_doc
         with:
           markdown_file: docs/${{ matrix.document }}.md

--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -9,17 +9,17 @@ jobs:
           - 'EVG'
           - 'NSR'
     name: Build ${{ matrix.document }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout old version for redline
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.push.before }}
           path: old/
-      - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.1.0
+      - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.2.0
         id: build_doc
         with:
           markdown_file: docs/${{ matrix.document }}.md


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build-draft-docs.yml` file to use newer versions of the tools and environments.

Updates to the build environment and tools:

* Changed the runner from `ubuntu-20.04` to `ubuntu-24.04` to use a more recent version of the operating system.
* Updated `actions/checkout` from version `v3` to `v4` to use the latest version of the checkout action.
* Updated the `docker://ghcr.io/cabforum/build-guidelines-action` from version `2.1.0` to `2.2.0` to use the latest version of the build guidelines action.