### PR TITLE
SC-106: Enable Post-Quantum Cryptography (PQ) Key Pairs in TLS Server Certificates

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -575,6 +575,8 @@ FIPS 140-3, Federal Information Processing Standards Publication - Security Requ
 
 FIPS 186-5, Federal Information Processing Standards Publication - Digital Signature Standard (DSS), Information Technology Laboratory, National Institute of Standards and Technology, February 2023.
 
+FIPS 204, Federal Information Processing Standards Publication - Module-Lattice-Based Digital Signature Standard, Information Technology Laboratory, National Institute of Standards and Technology, August 2024.
+
 ISO 21188:2018, Public key infrastructure for financial services -- Practices and policy framework.
 
 Network and Certificate System Security Requirements, Version 1.7, available at <https://cabforum.org/network-security-requirements/>
@@ -2088,6 +2090,13 @@ For ECDSA key pairs, the CA SHALL:
 
 - Ensure that the key represents a valid point on the NIST P-256, NIST P-384 or NIST P-521 elliptic curve.
 
+For ML-DSA key pairs, the CA SHALL:
+
+- Ensure that the key uses one of the following parameter sets, as specified in FIPS 204:
+  - ML-DSA-44 (OID: 2.16.840.1.101.3.4.3.17),
+  - ML-DSA-65 (OID: 2.16.840.1.101.3.4.3.18), or
+  - ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
+
 No other algorithms or key sizes are permitted.
 
 ### 6.1.6 Public key parameters generation and quality checking
@@ -2095,6 +2104,8 @@ No other algorithms or key sizes are permitted.
 RSA: The CA SHALL confirm that the value of the public exponent is an odd number equal to 3 or more. Additionally, the public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1. The modulus SHOULD also have the following characteristics: an odd number, not the power of a prime, and have no factors smaller than 752. [Source: Section 5.3.3, NIST SP 800-89]
 
 ECDSA: The CA SHOULD confirm the validity of all keys using either the ECC Full Public Key Validation Routine or the ECC Partial Public Key Validation Routine. [Source: Sections 5.6.2.3.2 and 5.6.2.3.3, respectively, of NIST SP 800-56A: Revision 2]
+
+ML-DSA: The CA SHALL confirm that the public key is a valid encoding for the specified parameter set per FIPS 204.
 
 ### 6.1.7 Key usage purposes (as per X.509 v3 key usage field)
 
@@ -2894,7 +2905,7 @@ Table: Permitted `policyQualifiers`
 
 ##### 7.1.2.7.11 Subscriber Certificate Key Usage
 
-The acceptable Key Usage values vary based on whether the Certificate's `subjectPublicKeyInfo` identifies an RSA public key or an ECC public key. CAs MUST ensure the Key Usage is appropriate for the Certificate Public Key.
+The acceptable Key Usage values vary based on whether the Certificate's `subjectPublicKeyInfo` identifies an RSA public key, an ECC public key, or an ML-DSA public key. CAs MUST ensure the Key Usage is appropriate for the Certificate Public Key.
 
 Table: Key Usage for RSA Public Keys
 
@@ -2927,6 +2938,20 @@ Table: Key Usage for ECC Public Keys
 | `decipherOnly`     | N             | --               |
 
 **Note**: The `keyAgreement` bit is currently permitted, although setting it is NOT RECOMMENDED, as it is a Pending Prohibition (<https://github.com/cabforum/servercert/issues/384>).
+
+Table: Key Usage for ML-DSA Public Keys
+
+| **Key Usage**      | **Permitted** | **Required**     |
+| -----              | --            | ---              |
+| `digitalSignature` | Y             | MUST             |
+| `nonRepudiation`   | N             | --               |
+| `keyEncipherment`  | N             | --               |
+| `dataEncipherment` | N             | --               |
+| `keyAgreement`     | N             | --               |
+| `keyCertSign`      | N             | --               |
+| `cRLSign`          | N             | --               |
+| `encipherOnly`     | N             | --               |
+| `decipherOnly`     | N             | --               |
 
 ##### 7.1.2.7.12 Subscriber Certificate Subject Alternative Name
 
@@ -3406,6 +3431,22 @@ When encoded, the `AlgorithmIdentifier` for ECDSA keys MUST be byte-for-byte ide
 - For P-384 keys, `301006072a8648ce3d020106052b81040022`.
 - For P-521 keys, `301006072a8648ce3d020106052b81040023`.
 
+##### 7.1.3.1.3 ML-DSA
+
+The CA SHALL indicate an ML-DSA key using one of the following algorithm identifiers:
+
+- id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17),
+- id-ml-dsa-65 (OID: 2.16.840.1.101.3.4.3.18), or
+- id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19).
+
+The parameters for ML-DSA keys SHALL be absent. The CA MUST NOT use HashML-DSA, as specified in FIPS 204; only "pure" ML-DSA is permitted. Additionally, the CA SHALL NOT use these algorithm identifiers if the algorithm identifier of the Certificate's signature algorithm is not one of id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17), id-ml-dsa-65 (OID: 2.16.840.1.101.3.4.3.18), or id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19).
+
+When encoded, the `AlgorithmIdentifier` for ML-DSA keys MUST be byte-for-byte identical with the following hex-encoded bytes:
+
+- For id-ml-dsa-44, `300b0609608648016503040311`.
+- For id-ml-dsa-65, `300b0609608648016503040312`.
+- For id-ml-dsa-87, `300b0609608648016503040313`.
+
 #### 7.1.3.2 Signature AlgorithmIdentifier
 
 All objects signed by a CA Private Key MUST conform to these requirements on the use of the `AlgorithmIdentifier` or `AlgorithmIdentifier`-derived type in the context of signatures.
@@ -3513,6 +3554,18 @@ If the signing key is P-256, the signature MUST use ECDSA with SHA-256. When enc
 If the signing key is P-384, the signature MUST use ECDSA with SHA-384. When encoded, the `AlgorithmIdentifier` MUST be byte-for-byte identical with the following hex-encoded bytes: `300a06082a8648ce3d040303`.
 
 If the signing key is P-521, the signature MUST use ECDSA with SHA-512. When encoded, the `AlgorithmIdentifier` MUST be byte-for-byte identical with the following hex-encoded bytes: `300a06082a8648ce3d040304`.
+
+##### 7.1.3.2.3 ML-DSA
+
+The CA SHALL use the appropriate signature algorithm and encoding based upon the signing key used.
+
+If the signing key is ML-DSA-44, the signature algorithm MUST be id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17). When encoded, the `AlgorithmIdentifier` MUST be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040311`.
+
+If the signing key is ML-DSA-65, the signature algorithm MUST be id-ml-dsa-65 (OID: 2.16.840.1.101.3.4.3.18). When encoded, the `AlgorithmIdentifier` MUST be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040312`.
+
+If the signing key is ML-DSA-87, the signature algorithm MUST be id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19). When encoded, the `AlgorithmIdentifier` MUST be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040313`.
+
+If used within a Certificate or Precertificate, such as the `signatureAlgorithm` field of a Certificate or the `signature` field of a TBSCertificate, the CA SHALL NOT use these signature algorithms unless the algorithm identifier of the public key being certified is one of id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17), id-ml-dsa-65 (OID: 2.16.840.1.101.3.4.3.18), or id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19). This restriction does not apply if used within a CRL, such as the `signatureAlgorithm` field of a CertificateList, or within an OCSP response, such as the `signatureAlgorithm` of a BasicOCSPResponse, as these objects do not certify a public key.
 
 ### 7.1.4 Name Forms
 


### PR DESCRIPTION
## Summary

This ballot adds ML-DSA (FIPS 204) as a permitted key and signature algorithm in publicly-trusted TLS server certificates, including ML-DSA-signed CA certificates, CRLs, and OCSP responses, enabling the certificate ecosystem to begin migrating to post-quantum authentication. Passing this ballot does not compel any Root Store Operator to accept ML-DSA. Whether ML-DSA certificates are trusted within a root program's hierarchy remains governed entirely by that program's own policy, and those policies today restrict keys to RSA and ECDSA. Passing this ballot also does not change the signature algorithm used in the Signed Certificate Timestamps embedded in these certificates as that remains in the control of Certificate Transparency log operators. Many Relying Parties validate server certificates through system and library trust stores and have no practical path to post-quantum authentication within the existing X.509 public trust infrastructure. These include SDK-based service clients, embedded and IoT systems, enterprise middleware, and applications that authenticate against system trust stores managed by operating system vendors. This profile must exist at the CA/B Forum level before CAs can issue these certificates and Root Store Operators can decide to trust them.

## Policy Rationale

### Why not permit mixed classical and post-quantum chains?

ML-DSA exists to provide authentication that remains sound once a cryptographically relevant quantum computer exists. That guarantee holds only if every signature on the path to a certificate is itself post-quantum. A classical link anywhere in the chain, including a classical certificate that cross-signs an ML-DSA CA, leaves the authentication of everything beneath it only as strong as that classical signature, which a quantum adversary can forge. Requiring ML-DSA certificates to chain to ML-DSA issuers ensures that a chain presented as post-quantum provides post-quantum authentication end to end, and does not quietly reduce to classical strength at a cross-signature or a classical issuer.

The same rule has a practical effect on Certificate Transparency as well. ML-DSA public keys and signatures are much larger than their classical counterparts, and logs accept submissions by root rather than by algorithm, so a log serving a classical root cannot decline the ML-DSA certificates issued beneath it. By keeping ML-DSA out from under classical roots, the rule leaves the decision whether to carry these larger payloads with root programs and Certificate Transparency programs rather than settling it in the certificate profile.
